### PR TITLE
Use octopus-components-registry-service.version property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ configure<ComposeExtension> {
         mapOf(
             "DOCKER_REGISTRY" to properties["docker.registry"],
             "TEAMCITY_VERSION" to "2021.1.4",
-            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["components-registry-service.version"],
+            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"],
         )
     )
 }
@@ -66,7 +66,7 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.3.14")
     implementation("com.github.ajalt.clikt:clikt:4.4.0")
     implementation("org.octopusden.octopus.octopus-external-systems-clients:teamcity-client:${properties["teamcity-client.version"]}")
-    implementation("org.octopusden.octopus.infrastructure:components-registry-service-client:${properties["components-registry-service-client.version"]}")
+    implementation("org.octopusden.octopus.infrastructure:components-registry-service-client:${properties["octopus-components-registry-service.version"]}")
     with("5.9.2") {
         testImplementation("org.junit.jupiter:junit-jupiter-api:$this")
         testImplementation("org.junit.jupiter:junit-jupiter-params:$this")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 teamcity-client.version=2.0.47
-components-registry-service-client.version=2.0.35
+octopus-components-registry-service.version=2.0.35
 
 version=1.0-SNAPSHOT
 docker.registry=


### PR DESCRIPTION
Rename `components-registry-service-client.version` property to `octopus-components-registry-service.version` that will be used for `components-registry-service-client` dependency and `COMPONENTS_REGISTRY_SERVICE_VERSION` docker image.