### PR TITLE
Add rm-gradle-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin")
     signing
-    id("com.jfrog.artifactory")
+    id("org.octopusden.octopus-release-management")
 }
 
 group = "org.octopusden.octopus.automation.teamcity"
@@ -108,26 +108,6 @@ val metarunners = artifacts.add(
     classifier = "metarunners"
     type = "zip"
     builtBy("zipMetarunners")
-}
-
-artifactory {
-    publish {
-        val baseUrl = System.getenv("ARTIFACTORY_URL") ?: project.findProperty("artifactoryUrl") as String?
-        if (baseUrl != null) {
-            contextUrl = "$baseUrl/artifactory"
-        }
-
-        repository {
-            repoKey = System.getenv("ARTIFACTORY_REPOSITORY_KEY") ?: project.findProperty("artifactoryRepositoryKey") as String?
-            username = System.getenv("ARTIFACTORY_DEPLOYER_USERNAME") ?: project.findProperty("NEXUS_USER") as String?
-            password = System.getenv("ARTIFACTORY_DEPLOYER_PASSWORD") ?: project.findProperty("NEXUS_PASSWORD") as String?
-        }
-
-        defaults {
-            publications("ALL_PUBLICATIONS")
-            isPublishBuildInfo = true
-        }
-    }
 }
 
 nexusPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     `maven-publish`
     id("io.github.gradle-nexus.publish-plugin")
     signing
+    id("com.jfrog.artifactory")
 }
 
 group = "org.octopusden.octopus.automation.teamcity"
@@ -107,6 +108,26 @@ val metarunners = artifacts.add(
     classifier = "metarunners"
     type = "zip"
     builtBy("zipMetarunners")
+}
+
+artifactory {
+    publish {
+        val baseUrl = System.getenv("ARTIFACTORY_URL") ?: project.findProperty("artifactoryUrl") as String?
+        if (baseUrl != null) {
+            contextUrl = "$baseUrl/artifactory"
+        }
+
+        repository {
+            repoKey = System.getenv("ARTIFACTORY_REPOSITORY_KEY") ?: project.findProperty("artifactoryRepositoryKey") as String?
+            username = System.getenv("ARTIFACTORY_DEPLOYER_USERNAME") ?: project.findProperty("NEXUS_USER") as String?
+            password = System.getenv("ARTIFACTORY_DEPLOYER_PASSWORD") ?: project.findProperty("NEXUS_PASSWORD") as String?
+        }
+
+        defaults {
+            publications("ALL_PUBLICATIONS")
+            isPublishBuildInfo = true
+        }
+    }
 }
 
 nexusPublishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 teamcity-client.version=2.0.47
 octopus-components-registry-service.version=2.0.35
+octopus-release-management.version=2.0.28
 
 version=1.0-SNAPSHOT
 docker.registry=

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,12 @@
 pluginManagement {
+    val releaseManagementVersion = extra["octopus-release-management.version"] as String
+
     plugins {
         id("org.jetbrains.kotlin.jvm") version ("1.9.20")
         id("com.github.johnrengelman.shadow") version ("8.1.1")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
-        id("org.octopusden.octopus-release-management") version ("2.0.28")
+        id("org.octopusden.octopus-release-management") version(releaseManagementVersion)
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,6 +4,7 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version ("8.1.1")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
+        id("com.jfrog.artifactory") version ("5.2.5")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version ("8.1.1")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
-        id("com.jfrog.artifactory") version ("5.2.5")
+        id("org.octopusden.octopus-release-management") version ("2.0.28")
     }
 }
 


### PR DESCRIPTION
Add the `rm-gradle-plugin` to enable `artifactoryPublish` task for publishing artifacts to JFrog Artifactory. 

**Upgrade Notes:**
To override the plugin version, set the `octopus-release-management.version` property at `GRADLE_EXTRA_PARAMETERS`.