### PR TITLE
Remove legacy staging parameter STAGING_REPOSITORY_ID

### DIFF
--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -135,11 +135,6 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             disableBuildStep(releaseConfig.id, "Deploy to Share")
         }
         setBuildTypeParameter(releaseConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
-        setBuildTypeParameter(
-            releaseConfig.id,
-            "STAGING_REPOSITORY_ID",
-            "%dep.${compileConfig.id}.STAGING_REPOSITORY_ID%"
-        )
         setProjectParameter(project.id, "COMPONENT_NAME", componentName)
         setProjectParameter(project.id, "RELENG_SKIP", "false")
         setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -220,7 +220,6 @@ class ApplicationTest {
         Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
         Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
         Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-        Assertions.assertEquals("%dep.$compileConfigId.STAGING_REPOSITORY_ID%", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "STAGING_REPOSITORY_ID"))
 
         Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
         Assertions.assertEquals("false", teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "RELENG_SKIP"))
@@ -281,7 +280,6 @@ class ApplicationTest {
 
             val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
             Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-            Assertions.assertEquals("%dep.$compileConfigId.STAGING_REPOSITORY_ID%", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "STAGING_REPOSITORY_ID"))
 
             Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
             Assertions.assertEquals("false", teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "RELENG_SKIP"))


### PR DESCRIPTION
Remove processing of outdated STAGING_REPOSITORY_ID parameter. It was used for Nexus only.