### PR TITLE
Docker permissions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,8 @@ dockerCompose.isRequiredBy(tasks["test"])
 tasks.register<Sync>("prepareTeamcityServerData") {
     from(zipTree(layout.projectDirectory.file("docker/data.zip")))
     into(layout.buildDirectory.dir("teamcity-server"))
-    dirPermissions(777)
+    filePermissions { unix("rwxrwxrwx") }
+    dirPermissions { unix("drwxrwxrwx") }
 }
 
 tasks.named("composeUp") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dockerCompose.isRequiredBy(tasks["test"])
 tasks.register<Sync>("prepareTeamcityServerData") {
     from(zipTree(layout.projectDirectory.file("docker/data.zip")))
     into(layout.buildDirectory.dir("teamcity-server"))
+    dirPermissions(777)
 }
 
 tasks.named("composeUp") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,7 @@ tasks.register<Sync>("prepareTeamcityServerData") {
     from(zipTree(layout.projectDirectory.file("docker/data.zip")))
     into(layout.buildDirectory.dir("teamcity-server"))
     filePermissions { unix("rwxrwxrwx") }
-    dirPermissions { unix("drwxrwxrwx") }
+    dirPermissions { unix("rwxrwxrwx") }
 }
 
 tasks.named("composeUp") {


### PR DESCRIPTION
Simple fix for the docker user problem 

The following issue can appear because of static user binding is incorrect. 

```
Execution failed for task ':composeUp'. java.lang.RuntimeException: Container aa8bd22df7931e6e62e2705f4f62cca35828122df4708748d85d53c0b6171494 of teamcity_1 is not running nor restarting. Logs:
/run-services.sh
/services/check-server-volumes.sh

>>> Permission problem: TEAMCITY_DATA_PATH '/data/teamcity_server/datadir' is not a writeable directory
>>> Permission problem: TEAMCITY_LOGS '/opt/teamcity/logs' is not a writeable directory

    Looks like some mandatory directories are not writable (see above).
    TeamCity container is running under 'tcuser' (1000/1000) user.

    A quick workaround: pass '-u 0' parameter to 'docker run' command to start it under 'root' user.
    The proper fix: run 'chown -R 1000:1000' on the corresponding volume(s), this can take noticeable time.

```