### PR TITLE
Parametrize check list validation

### DIFF
--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -54,7 +54,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private val checkListValidation by option(CHECKLIST, help = "Generate check list validation")
         .convert { it.trim().toBoolean() }.default(true)
 
-    private val createRc by option(CREATE_RC, help = "Generate check list validation")
+    private val createRc by option(CREATE_RC, help = "Generate RC for non EE components")
         .convert { it.trim().toBoolean() }.default(false)
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -4,7 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.requireObject
 import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.convert
-import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
@@ -51,9 +51,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private val componentsRegistryUrl by option(CR, help = "Components Registry service Url").required()
         .check("$CR is empty") { it.isNotEmpty() }
 
-    private val checkListValidation by option(CHECKLIST, help = "Generate check list validation").flag(default = true)
+    private val checkListValidation by option(CHECKLIST, help = "Generate check list validation")
+        .convert { it.trim().toBoolean() }.default(true)
 
-    private val createRc by option(CREATE_RC, help = "Generate check list validation").flag(default = false)
+    private val createRc by option(CREATE_RC, help = "Generate check list validation")
+        .convert { it.trim().toBoolean() }.default(false)
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -51,10 +51,10 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private val componentsRegistryUrl by option(CR, help = "Components Registry service Url").required()
         .check("$CR is empty") { it.isNotEmpty() }
 
-    private val checkListValidation by option(CHECKLIST, help = "Generate check list validation")
+    private val createChecklist by option(CREATE_CHECKLIST, help = "Generate check list validation")
         .convert { it.trim().toBoolean() }.default(true)
 
-    private val createRc by option(CREATE_RC, help = "Generate RC for non EE components")
+    private val createRcForce by option(CREATE_RC_FORCE, help = "Force generate RC for non EE components")
         .convert { it.trim().toBoolean() }.default(false)
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
@@ -99,7 +99,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
         }
         val releaseConfig =
-            if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRc) {
+            if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRcForce) {
                 val rcConfig = createBuildConf(
                     TEMPLATE_RC,
                     "[${++counter}.0] Release Candidate [Manual]",
@@ -107,7 +107,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 )
                 attachVcsRootToBuildType(rcConfig.id, vcsRootId)
 
-                if (checkListValidation) {
+                if (createChecklist) {
                     val checklistConfig = createBuildConf(
                         TEMPLATE_CHECKLIST,
                         "[${++counter}.0] Release Checklist Validation [MANUAL]",
@@ -242,8 +242,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         const val COMPONENT = "--component"
         const val VERSION = "--minor-version"
         const val CR = "--registry-url"
-        const val CHECKLIST = "--check-list-validation"
-        const val CREATE_RC = "--create-rc"
+        const val CREATE_CHECKLIST = "--create-checklist"
+        const val CREATE_RC_FORCE = "--create-rc-force"
 
         const val TEMPLATE_GRADLE_COMPILE = "CDCompileUTGradle"
         const val TEMPLATE_MAVEN_COMPILE = "CDCompileUTMaven"

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -49,7 +49,13 @@ class ApplicationTest {
             File("").resolve("build").resolve("logs").resolve("$name.log").also { it.parentFile.mkdirs() }).start()
             .waitFor()
 
-    private fun executeForCreateBuildChainCommand(componentName: String, minorVersion: String? = "1.0", testMethodName: String): Int =
+    private fun executeForCreateBuildChainCommand(
+        testMethodName: String,
+        componentName: String,
+        minorVersion: String? = "1.0",
+        checkListValidation: Boolean = true,
+        createRc: Boolean = false
+    ): Int =
         execute(
             testMethodName,
             *TEAMCITY_OPTIONS,
@@ -58,6 +64,8 @@ class ApplicationTest {
             "${TeamcityCreateBuildChainCommand.COMPONENT}=$componentName",
             "${TeamcityCreateBuildChainCommand.VERSION}=$minorVersion",
             "${TeamcityCreateBuildChainCommand.CR}=$COMPONENTS_REGISTRY_SERVICE_URL",
+            "${TeamcityCreateBuildChainCommand.CHECKLIST}=$checkListValidation",
+            "${TeamcityCreateBuildChainCommand.CREATE_RC}=$createRc",
         )
 
     private fun validateBuildTypeTemplate(buildTypeId: String, templateId: String) {
@@ -162,6 +170,8 @@ class ApplicationTest {
         )
     }
 
+    private fun TestInfo.methodName() = testMethod.get().name
+
     /**
      * Tests CreateTeamCityBuildChain for explicit & external components.
      * Verifies:
@@ -178,7 +188,7 @@ class ApplicationTest {
         val componentName = "ee-component"
 
         Assertions.assertEquals(
-            0, executeForCreateBuildChainCommand(componentName, minorVersion, testInfo.testMethod.get().name)
+            0, executeForCreateBuildChainCommand(testInfo.methodName(), componentName, minorVersion)
         )
 
         val projectId = "TestTeamcityAutomation_EeComponent"
@@ -223,6 +233,69 @@ class ApplicationTest {
 
         Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
         Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
+        teamcityClient.deleteProject(projectId)
+    }
+
+    @Test
+    fun testTeamCityCreateBuildChainForEEComponentWithoutCheckList(testInfo: TestInfo) {
+        val minorVersion = "1.0"
+        val componentName = "ee-component"
+
+        Assertions.assertEquals(
+            0, executeForCreateBuildChainCommand(testInfo.methodName(), componentName, minorVersion, false)
+        )
+
+        val projectId = "TestTeamcityAutomation_EeComponent"
+        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+        Assertions.assertEquals(3, buildTypes.size)
+
+        val compileConfigId = "${projectId}_10CompileUtAuto"
+        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+        val releaseConfigId = "${projectId}_30ReleaseManual"
+
+        validateBuildTypeTemplate(rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+        validateBuildTypeTemplate(releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+
+        val buildTypesIdAndDependencyId = mapOf(
+            compileConfigId to null,
+            rcConfigId to compileConfigId,
+            releaseConfigId to rcConfigId
+        )
+
+        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+            dependencyId?.let {
+                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                Assertions.assertEquals(1, snapshotDependencies.size)
+                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+            }
+        }
+
+        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+        Assertions.assertEquals(2, buildSteps.size)
+        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
+        )
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+        )
+
+        Assertions.assertEquals(
+            componentName,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+        )
+        Assertions.assertEquals(
+            minorVersion,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+        )
+        teamcityClient.deleteProject(projectId)
     }
 
     /**
@@ -246,7 +319,7 @@ class ApplicationTest {
 
         componentNamesToProjectId.forEach { (componentName, projectId) ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(componentName, minorVersion, testInfo.testMethod.get().name)
+                0, executeForCreateBuildChainCommand(testInfo.methodName(), componentName, minorVersion)
             )
 
             Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
@@ -282,7 +355,73 @@ class ApplicationTest {
 
             Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
             Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
+            teamcityClient.deleteProject(projectId)
         }
+    }
+
+    @Test
+    fun testTeamCityCreateBuildChainForIEComponentWithRc(testInfo: TestInfo) {
+        val minorVersion = "1.0"
+        val projectId = "TestTeamcityAutomation_IeComponent"
+        val componentName = "ie-component"
+
+        Assertions.assertEquals(
+            0,
+            executeForCreateBuildChainCommand(
+                testInfo.methodName(),
+                componentName,
+                minorVersion,
+                checkListValidation = false,
+                createRc = true
+            )
+        )
+
+        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+        Assertions.assertEquals(3, buildTypes.size)
+
+        val compileConfigId = "${projectId}_10CompileUtAuto"
+        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+        val releaseConfigId = "${projectId}_30ReleaseManual"
+
+        validateBuildTypeTemplate(rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+        validateBuildTypeTemplate(releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+
+        val buildTypesIdAndDependencyId = mapOf(
+            compileConfigId to null,
+            rcConfigId to compileConfigId,
+            releaseConfigId to rcConfigId
+        )
+
+        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+            dependencyId?.let {
+                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                Assertions.assertEquals(1, snapshotDependencies.size)
+                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+            }
+        }
+
+        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+        Assertions.assertEquals(2, buildSteps.size)
+        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+        )
+
+        Assertions.assertEquals(
+            componentName,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+        )
+        Assertions.assertEquals(
+            minorVersion,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+        )
+        teamcityClient.deleteProject(projectId)
     }
 
     /**
@@ -302,7 +441,7 @@ class ApplicationTest {
 
         componentNamesToProjectId.forEach { (componentName, projectId) ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(componentName, testMethodName = testInfo.testMethod.get().name)
+                0, executeForCreateBuildChainCommand(testInfo.methodName(), componentName)
             )
             val nonCompileConfigIds = listOf(
                 "${projectId}_20ReleaseCandidateManual",
@@ -331,7 +470,7 @@ class ApplicationTest {
 
         componentNames.forEach { componentName ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(componentName, testMethodName = testInfo.testMethod.get().name)
+                0, executeForCreateBuildChainCommand(testInfo.methodName(), componentName)
             )
         }
 
@@ -340,7 +479,7 @@ class ApplicationTest {
         validateBuildTypeTemplate("TestTeamcityAutomation_ProvidedComponent_10CompileUtAuto", TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE)
 
         Assertions.assertEquals(
-            1, executeForCreateBuildChainCommand("not-supported-component", testMethodName = testInfo.testMethod.get().name)
+            1, executeForCreateBuildChainCommand(testInfo.methodName(), "not-supported-component")
         )
     }
 

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -53,8 +53,8 @@ class ApplicationTest {
         testMethodName: String,
         componentName: String,
         minorVersion: String? = "1.0",
-        checkListValidation: Boolean = true,
-        createRc: Boolean = false
+        createChecklist: Boolean = true,
+        createRcForce: Boolean = false
     ): Int =
         execute(
             testMethodName,
@@ -64,8 +64,8 @@ class ApplicationTest {
             "${TeamcityCreateBuildChainCommand.COMPONENT}=$componentName",
             "${TeamcityCreateBuildChainCommand.VERSION}=$minorVersion",
             "${TeamcityCreateBuildChainCommand.CR}=$COMPONENTS_REGISTRY_SERVICE_URL",
-            "${TeamcityCreateBuildChainCommand.CHECKLIST}=$checkListValidation",
-            "${TeamcityCreateBuildChainCommand.CREATE_RC}=$createRc",
+            "${TeamcityCreateBuildChainCommand.CREATE_CHECKLIST}=$createChecklist",
+            "${TeamcityCreateBuildChainCommand.CREATE_RC_FORCE}=$createRcForce",
         )
 
     private fun validateBuildTypeTemplate(buildTypeId: String, templateId: String) {
@@ -371,8 +371,8 @@ class ApplicationTest {
                 testInfo.methodName(),
                 componentName,
                 minorVersion,
-                checkListValidation = false,
-                createRc = true
+                createChecklist = false,
+                createRcForce = true
             )
         )
 


### PR DESCRIPTION
Added two parameters to Create Build Chain 
--create-checklist -  Generate check list validation(All build steps added to RC). Default true
--create-rc-force - Generate RC for non EE components