### PR TITLE
Migrate tests to OKD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -206,6 +206,10 @@ tasks.named("ocCreateTeamcityServers").configure {
     dependsOn(seedTeamcity)
 }
 
+tasks.named("ocDeleteTeamcityPVCs").configure {
+    dependsOn("ocDeleteTeamcityServers")
+}
+
 tasks.withType<Test> {
     when ("testPlatform".getExt()) {
         "okd" -> {
@@ -222,7 +226,6 @@ tasks.withType<Test> {
             finalizedBy(
                 "ocLogsTeamcityServers",
                 "ocLogsComponentsRegistry",
-                "ocDeleteTeamcityServers",
                 "ocDeleteTeamcityPVCs",
                 "ocDeleteComponentsRegistry"
             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,23 @@ if (project.ext["testPlatform"] == "okd") {
     mandatoryProperties.add("okdProject")
     mandatoryProperties.add("okdClusterDomain")
 }
+val undefinedProperties = mandatoryProperties.filter { (project.ext[it] as String).isBlank() }
+if (undefinedProperties.isNotEmpty()) {
+    throw IllegalArgumentException(
+        "Start gradle build with" +
+                (if (undefinedProperties.contains("dockerRegistry")) " -Pdocker.registry=..." else "") +
+                (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " -Poctopus.github.docker.registry=..." else "") +
+                (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " -Pokd.active-deadline-seconds=..." else "") +
+                (if (undefinedProperties.contains("okdProject")) " -Pokd.project=..." else "") +
+                (if (undefinedProperties.contains("okdClusterDomain")) " -Pokd.cluster-domain=..." else "") +
+                " or set env variable(s):" +
+                (if (undefinedProperties.contains("dockerRegistry")) " DOCKER_REGISTRY" else "") +
+                (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " OCTOPUS_GITHUB_DOCKER_REGISTRY" else "") +
+                (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " OKD_ACTIVE_DEADLINE_SECONDS" else "") +
+                (if (undefinedProperties.contains("okdProject")) " OKD_PROJECT" else "") +
+                (if (undefinedProperties.contains("okdClusterDomain")) " OKD_CLUSTER_DOMAIN" else "")
+    )
+}
 fun String.getExt() = project.ext[this].toString()
 
 val commonOkdParameters = mapOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import com.avast.gradle.dockercompose.ComposeExtension
 import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.net.InetAddress
+import java.util.zip.CRC32
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -12,6 +14,18 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin")
     signing
     id("org.octopusden.octopus-release-management")
+    id("org.octopusden.octopus.oc-template")
+}
+
+val defaultVersion = "${
+    with(CRC32()) {
+        update(InetAddress.getLocalHost().hostName.toByteArray())
+        value
+    }
+}-snapshot"
+
+if (version == "unspecified") {
+    version = defaultVersion
 }
 
 group = "org.octopusden.octopus.automation.teamcity"
@@ -30,12 +44,108 @@ repositories {
     mavenCentral()
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-    testLogging {
-        info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+ext {
+    System.getenv().let {
+        set("signingRequired", it.containsKey("ORG_GRADLE_PROJECT_signingKey") && it.containsKey("ORG_GRADLE_PROJECT_signingPassword"))
+        set("testPlatform", it.getOrDefault("TEST_PLATFORM", properties["test.platform"]))
+        set("dockerRegistry", it.getOrDefault("DOCKER_REGISTRY", properties["docker.registry"]))
+        set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]))
+        set("okdActiveDeadlineSeconds", it.getOrDefault("OKD_ACTIVE_DEADLINE_SECONDS", properties["okd.active-deadline-seconds"]))
+        set("okdProject", it.getOrDefault("OKD_PROJECT", properties["okd.project"]))
+        set("okdClusterDomain", it.getOrDefault("OKD_CLUSTER_DOMAIN", properties["okd.cluster-domain"]))
+        set("okdWebConsoleUrl", (it.getOrDefault("OKD_WEB_CONSOLE_URL", properties["okd.web-console-url"]) as String).trimEnd('/'))
     }
-    systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
+}
+val supportedTestPlatforms = listOf("docker", "okd")
+if (project.ext["testPlatform"] !in supportedTestPlatforms) {
+    throw IllegalArgumentException("Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM")
+}
+val mandatoryProperties = mutableListOf("dockerRegistry", "octopusGithubDockerRegistry")
+if (project.ext["testPlatform"] == "okd") {
+    mandatoryProperties.add("okdActiveDeadlineSeconds")
+    mandatoryProperties.add("okdProject")
+    mandatoryProperties.add("okdClusterDomain")
+}
+fun String.getExt() = project.ext[this].toString()
+
+val commonOkdParameters = mapOf(
+    "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+    "DOCKER_REGISTRY" to "dockerRegistry".getExt()
+)
+
+ocTemplate {
+    workDir.set(layout.buildDirectory.dir("okd"))
+    clusterDomain.set("okdClusterDomain".getExt())
+    namespace.set("okdProject".getExt())
+    prefix.set("tc-auto")
+    projectVersion.set(defaultVersion)
+
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+        webConsoleUrl.set(it)
+    }
+
+    group("teamcityPVCs").apply {
+        service("teamcity22-pvc") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-pvc.yaml"))
+            parameters.set(mapOf(
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+        service("teamcity25-pvc") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-pvc.yaml"))
+            parameters.set(mapOf(
+                "TEAMCITY_ID" to "25"
+            ))
+        }
+    }
+
+    group("teamcitySeedUploaders").apply {
+        service("teamcity22-uploader") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
+            parameters.set(mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+        service("teamcity25-uploader") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
+            parameters.set(mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
+                "TEAMCITY_ID" to "25"
+            ))
+        }
+    }
+
+    group("teamcityServers").apply {
+        service("teamcity22") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
+                "TEAMCITY_ID" to "22"
+            ))
+        }
+        service("teamcity25") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2025.image-tag"] as String,
+                "TEAMCITY_ID" to "25"
+            ))
+        }
+    }
+
+    group("componentsRegistry").apply {
+        service("comp-reg") {
+            templateFile.set(rootProject.layout.projectDirectory.file("okd/components-registry.yaml"))
+            parameters.set(commonOkdParameters + mapOf(
+                "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"] as String,
+                "CONFIGMAP_NAME" to "tc-auto-comp-reg-config-$defaultVersion"
+            ))
+        }
+    }
 }
 
 configure<ComposeExtension> {
@@ -44,29 +154,113 @@ configure<ComposeExtension> {
     captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
     environment.putAll(
         mapOf(
-            "DOCKER_REGISTRY" to properties["docker.registry"],
-            "TEAMCITY_VERSION" to "2022.04.7",
-            "TEAMCITY_V25_VERSION" to "2025.03.3",
-            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"],
+            "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
+            "TEAMCITY_2022_IMAGE_TAG" to properties["teamcity-2022.image-tag"],
+            "TEAMCITY_2025_IMAGE_TAG" to properties["teamcity-2025.image-tag"],
+            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"]
         )
     )
 }
 
-dockerCompose.isRequiredBy(tasks["test"])
-
-tasks.register<Sync>("prepareTeamcityServerData") {
-    from(zipTree(layout.projectDirectory.file("docker/data.zip")))
-    into(layout.buildDirectory.dir("teamcity-server"))
+val copyFilesTeamcity2022 = tasks.register<Exec>("copyFilesTeamcity2022") {
+    dependsOn("ocCreateTeamcityPVCs", "ocCreateTeamcitySeedUploaders")
+    val localFile = layout.projectDirectory.dir("docker/data.zip").asFile.absolutePath
+    commandLine("oc", "cp", localFile, "-n", "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity22-uploader")}:/seed/seed.zip")
 }
 
-tasks.register<Sync>("prepareTeamcityServerDataV25") {
-    from(zipTree(layout.projectDirectory.file("docker/dataV25.zip")))
-    into(layout.buildDirectory.dir("teamcity-server-2025"))
+val copyFilesTeamcity2025 = tasks.register<Exec>("copyFilesTeamcity2025") {
+    dependsOn("ocCreateTeamcityPVCs", "ocCreateTeamcitySeedUploaders")
+    val localFile = layout.projectDirectory.dir("docker/dataV25.zip").asFile.absolutePath
+    commandLine("oc", "cp", localFile, "-n", "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity25-uploader")}:/seed/seed.zip")
+}
+
+val createConfigMapComponentsRegistry = tasks.register<Exec>("createConfigMapComponentsRegistry") {
+    val applicationFtFile = layout.projectDirectory.dir("docker/components-registry-service.yaml").asFile.absolutePath
+    val componentsRegistryFiles = layout.projectDirectory.dir("src/test/resources/components-registry").asFile.absolutePath
+    commandLine(
+        "oc", "create", "configmap", "tc-auto-comp-reg-config-$defaultVersion",
+        "--from-file=application-ft.yaml=$applicationFtFile",
+        "--from-file=Aggregator.groovy=$componentsRegistryFiles/Aggregator.groovy",
+        "--from-file=Defaults.groovy=$componentsRegistryFiles/Defaults.groovy",
+        "--from-file=TestComponents.groovy=$componentsRegistryFiles/TestComponents.groovy",
+        "-n", "okdProject".getExt()
+    )
+}
+
+val deleteConfigMapComponentsRegistry = tasks.register<Exec>("deleteConfigMapComponentsRegistry") {
+    commandLine(
+        "oc", "delete", "configmap", "tc-auto-comp-reg-config-$defaultVersion",
+        "-n", "okdProject".getExt()
+    )
+}
+
+val seedTeamcity = tasks.register("seedTeamcity") {
+    dependsOn(copyFilesTeamcity2022, copyFilesTeamcity2025)
+    finalizedBy("ocLogsTeamcitySeedUploaders", "ocDeleteTeamcitySeedUploaders")
+}
+
+tasks.named("ocCreateTeamcityServers").configure {
+    dependsOn(seedTeamcity)
+}
+
+tasks.withType<Test> {
+    when ("testPlatform".getExt()) {
+        "okd" -> {
+            systemProperties["test.teamcity-2022-host"] = ocTemplate.getOkdHost("teamcity22")
+            systemProperties["test.teamcity-2025-host"] = ocTemplate.getOkdHost("teamcity25")
+            systemProperties["test.components-registry-host"] = ocTemplate.getOkdHost("comp-reg")
+
+            useJUnitPlatform()
+            testLogging {
+                info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+            }
+            systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
+
+            dependsOn(
+                createConfigMapComponentsRegistry,
+                "ocCreateTeamcityServers",
+                "ocCreateComponentsRegistry",
+                "shadowJar"
+            )
+            finalizedBy(
+                "ocLogsTeamcityServers",
+                "ocLogsComponentsRegistry",
+                "ocDeleteTeamcityServers",
+                "ocDeleteTeamcityPVCs",
+                "ocDeleteComponentsRegistry",
+                deleteConfigMapComponentsRegistry
+            )
+        }
+        "docker" -> {
+            systemProperties["test.teamcity-2022-host"] = "localhost:8111"
+            systemProperties["test.teamcity-2025-host"] = "localhost:8112"
+            systemProperties["test.components-registry-host"] = "localhost:4567"
+            dependsOn("shadowJar")
+            useJUnitPlatform()
+            testLogging {
+                info.events = setOf(TestLogEvent.FAILED, TestLogEvent.PASSED, TestLogEvent.SKIPPED)
+            }
+            systemProperties["jar"] = configurations["shadow"].artifacts.files.asPath
+            dockerCompose.isRequiredBy(this)
+        }
+    }
 }
 
 tasks.named("composeUp") {
-    dependsOn("prepareTeamcityServerData")
-    dependsOn("prepareTeamcityServerDataV25")
+    dependsOn(prepareTeamcity2022Data)
+    dependsOn(prepareTeamcity2025Data)
+}
+
+val prepareTeamcity2022Data = tasks.register<Sync>("prepareTeamcity2022Data") {
+    from(zipTree(layout.projectDirectory.file("docker/data.zip")))
+    into(layout.buildDirectory.dir("teamcity-server-2022"))
+}
+
+val prepareTeamcity2025Data = tasks.register<Sync>("prepareTeamcity2025Data") {
+    from(zipTree(layout.projectDirectory.file("docker/dataV25.zip")))
+    into(layout.buildDirectory.dir("teamcity-server-2025"))
 }
 
 dependencies {
@@ -163,8 +357,7 @@ publishing {
 }
 
 signing {
-    isRequired = System.getenv().containsKey("ORG_GRADLE_PROJECT_signingKey") && System.getenv()
-        .containsKey("ORG_GRADLE_PROJECT_signingPassword")
+    isRequired = "signingRequired".getExt().toBooleanStrict()
     val signingKey: String? by project
     val signingPassword: String? by project
     useInMemoryPgpKeys(signingKey, signingPassword)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -242,11 +242,6 @@ tasks.withType<Test> {
     }
 }
 
-tasks.named("composeUp") {
-    dependsOn(prepareTeamcity2022Data)
-    dependsOn(prepareTeamcity2025Data)
-}
-
 val prepareTeamcity2022Data = tasks.register<Sync>("prepareTeamcity2022Data") {
     from(zipTree(layout.projectDirectory.file("docker/data.zip")))
     into(layout.buildDirectory.dir("teamcity-server-2022"))
@@ -255,6 +250,11 @@ val prepareTeamcity2022Data = tasks.register<Sync>("prepareTeamcity2022Data") {
 val prepareTeamcity2025Data = tasks.register<Sync>("prepareTeamcity2025Data") {
     from(zipTree(layout.projectDirectory.file("docker/dataV25.zip")))
     into(layout.buildDirectory.dir("teamcity-server-2025"))
+}
+
+tasks.named("composeUp") {
+    dependsOn(prepareTeamcity2022Data)
+    dependsOn(prepareTeamcity2025Data)
 }
 
 dependencies {

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,21 +1,21 @@
 version: '3'
 
 services:
-  teamcity:
-    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_VERSION}
+  teamcity-2022:
+    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_2022_IMAGE_TAG}
     ports:
       - "8111:8111"
     volumes:
-      - ./../build/teamcity-server/datadir:/data/teamcity_server/datadir
-      - ./../build/teamcity-server/logs:/opt/teamcity/logs
+      - ./../build/teamcity-server-2022/datadir:/data/teamcity_server/datadir
+      - ./../build/teamcity-server-2022/logs:/opt/teamcity/logs
     healthcheck:
-      test: curl -u admin:admin -f teamcity:8111/app/rest/server >/dev/null || exit 1
+      test: curl -u admin:admin -f teamcity-2022:8111/app/rest/server >/dev/null || exit 1
       interval: 30s
       timeout: 10s
       retries: 5
 
   teamcity-2025:
-    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_V25_VERSION}
+    image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_2025_IMAGE_TAG}
     ports:
       - "8112:8111"
     volumes:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,16 @@
 teamcity-client.version=2.0.70
 octopus-components-registry-service.version=2.0.59
 octopus-release-management.version=2.0.28
+octopus-oc-template.version=2.0.4
 
-version=1.0-SNAPSHOT
-docker.registry=
+teamcity-2022.image-tag=2022.04.7
+teamcity-2025.image-tag=2025.03.3
+
+test.platform=docker
+docker.registry=docker.io
+octopus.github.docker.registry=ghcr.io
+okd.active-deadline-seconds=1800
+okd.project=
+okd.cluster-domain=
+okd.web-console-url=
+okd.service-account-anyuid=teamcity

--- a/okd/components-registry.yaml
+++ b/okd/components-registry.yaml
@@ -1,0 +1,92 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: components-registry-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-comp-reg
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      containers:
+        - name: comp-reg
+          image: ${DOCKER_REGISTRY}/octopusden/components-registry-service:${COMPONENTS_REGISTRY_SERVICE_VERSION}
+          ports:
+            - containerPort: 4567
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /rest/api/2/components-registry/service/ping
+              port: 4567
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          env:
+            - name: SPRING_CONFIG_ADDITIONAL_LOCATION
+              value: "/"
+            - name: SPRING_PROFILES_ACTIVE
+              value: "ft"
+            - name: SPRING_CLOUD_CONFIG_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: comp-reg-application-ft
+              mountPath: /application-ft.yaml
+              subPath: application-ft.yaml
+              readOnly: true
+            - name: comp-reg-config-dir
+              mountPath: /components-registry
+              readOnly: true
+      volumes:
+        - name: comp-reg-application-ft
+          configMap:
+            name: ${CONFIGMAP_NAME}
+        - name: comp-reg-config-dir
+          configMap:
+            name: ${CONFIGMAP_NAME}
+            items:
+              - key: Aggregator.groovy
+                path: Aggregator.groovy
+              - key: Defaults.groovy
+                path: Defaults.groovy
+              - key: TestComponents.groovy
+                path: TestComponents.groovy
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg-service
+    spec:
+      ports:
+        - port: 4567
+          protocol: TCP
+          targetPort: 4567
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-comp-reg
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-comp-reg-route
+    spec:
+      port:
+        targetPort: 4567
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-comp-reg-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Components registry service version
+    name: COMPONENTS_REGISTRY_SERVICE_VERSION
+    required: true
+  - name: CONFIGMAP_NAME
+    description: Name of pre-created ConfigMap with config files
+    required: true

--- a/okd/components-registry.yaml
+++ b/okd/components-registry.yaml
@@ -4,6 +4,19 @@ metadata:
   name: components-registry-template
 objects:
   - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
+    data:
+      Aggregator.groovy: |-
+        ${AGGREGATOR_GROOVY_CONTENT}
+      Defaults.groovy: |-
+        ${DEFAULTS_GROOVY_CONTENT}
+      TestComponents.groovy: |-
+        ${TEST_COMPONENTS_GROOVY_CONTENT}
+      application-ft.yaml: |-
+        ${APPLICATION_FT_CONTENT}
+  - apiVersion: v1
     kind: Pod
     metadata:
       name: ${DEPLOYMENT_PREFIX}-comp-reg
@@ -20,7 +33,7 @@ objects:
               protocol: TCP
           readinessProbe:
             httpGet:
-              path: /rest/api/2/components-registry/service/ping
+              path: /actuator/health/readiness
               port: 4567
             initialDelaySeconds: 10
             periodSeconds: 5
@@ -32,20 +45,17 @@ objects:
             - name: SPRING_CLOUD_CONFIG_ENABLED
               value: "false"
           volumeMounts:
-            - name: comp-reg-application-ft
+            - name: components-registry-dir
+              mountPath: /components-registry
+              readOnly: true
+            - name: application-ft
               mountPath: /application-ft.yaml
               subPath: application-ft.yaml
               readOnly: true
-            - name: comp-reg-config-dir
-              mountPath: /components-registry
-              readOnly: true
       volumes:
-        - name: comp-reg-application-ft
+        - name: components-registry-dir
           configMap:
-            name: ${CONFIGMAP_NAME}
-        - name: comp-reg-config-dir
-          configMap:
-            name: ${CONFIGMAP_NAME}
+            name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
             items:
               - key: Aggregator.groovy
                 path: Aggregator.groovy
@@ -53,6 +63,12 @@ objects:
                 path: Defaults.groovy
               - key: TestComponents.groovy
                 path: TestComponents.groovy
+        - name: application-ft
+          configMap:
+            name: ${DEPLOYMENT_PREFIX}-components-registry-config-data
+            items:
+              - key: application-ft.yaml
+                path: application-ft.yaml
   - apiVersion: v1
     kind: Service
     metadata:
@@ -87,6 +103,15 @@ parameters:
   - description: Components registry service version
     name: COMPONENTS_REGISTRY_SERVICE_VERSION
     required: true
-  - name: CONFIGMAP_NAME
-    description: Name of pre-created ConfigMap with config files
+  - description: Aggregator.groovy content
+    name: AGGREGATOR_GROOVY_CONTENT
+    required: true
+  - description: Defaults.groovy content
+    name: DEFAULTS_GROOVY_CONTENT
+    required: true
+  - description: TestComponents.groovy content
+    name: TEST_COMPONENTS_GROOVY_CONTENT
+    required: true
+  - description: application-ft.yaml content
+    name: APPLICATION_FT_CONTENT
     required: true

--- a/okd/teamcity-pvc.yaml
+++ b/okd/teamcity-pvc.yaml
@@ -1,0 +1,23 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-pvc-template
+objects:
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi
+      volumeMode: Filesystem
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/okd/teamcity-uploader.yaml
+++ b/okd/teamcity-uploader.yaml
@@ -1,0 +1,67 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-uploader-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-uploader
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-uploader
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      serviceAccountName: ${SERVICE_ACCOUNT_ANYUID}
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+        - name: seed
+          emptyDir: { }
+      containers:
+        - name: uploader
+          image: public.ecr.aws/docker/library/busybox:1.37
+          command: ["sh","-c"]
+          args:
+            - |
+              mkdir -p /seed /data/teamcity_server/datadir /opt/teamcity/logs
+              echo "Waiting for seed.zip..."
+              until [ -f /seed/seed.zip ]; do
+                sleep 1
+              done
+              until unzip -t /seed/seed.zip >/dev/null 2>&1; do
+                sleep 1
+              done
+              echo "Unzipping..."
+              mkdir -p /seed/unpacked
+              unzip -o /seed/seed.zip -d /seed/unpacked
+              if [ -d /seed/unpacked/datadir ]; then
+                echo "Copying datadir -> /data/teamcity_server/datadir"
+                cp -a /seed/unpacked/datadir/. /data/teamcity_server/datadir/
+              else
+                echo "!! /seed/unpacked/datadir not found"
+              fi
+              echo "Cleanup..."
+              rm -rf /seed/*
+              echo ">> Done, exiting."
+              exit 0
+          volumeMounts:
+            - name: datadir
+              mountPath: /data/teamcity_server/datadir
+            - name: seed
+              mountPath: /seed
+parameters:
+  - name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Service account name with SCC - anyuid
+    name: SERVICE_ACCOUNT_ANYUID
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/okd/teamcity.yaml
+++ b/okd/teamcity.yaml
@@ -1,0 +1,76 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: teamcity-template
+objects:
+  - apiVersion: v1
+    kind: Pod
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+      labels:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+    spec:
+      restartPolicy: Never
+      activeDeadlineSeconds: ${{ACTIVE_DEADLINE_SECONDS}}
+      serviceAccountName: ${SERVICE_ACCOUNT_ANYUID}
+      securityContext:
+        runAsUser: 0
+      volumes:
+        - name: teamcity${TEAMCITY_ID}-data
+          persistentVolumeClaim:
+            claimName: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-datadir
+      containers:
+        - name: teamcity${TEAMCITY_ID}
+          image: ${DOCKER_REGISTRY}/jetbrains/teamcity-server:${TEAMCITY_IMAGE_TAG}
+          ports:
+            - containerPort: 8111
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /login.html
+              port: 8111
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          volumeMounts:
+            - name: teamcity${TEAMCITY_ID}-data
+              mountPath: /data/teamcity_server/datadir
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-service
+    spec:
+      ports:
+        - port: 8111
+          protocol: TCP
+          targetPort: 8111
+      selector:
+        app.kubernetes.io/name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}
+  - apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-route
+    spec:
+      port:
+        targetPort: 8111
+      to:
+        kind: Service
+        name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-service
+parameters:
+  - description: Unique deployment prefix
+    name: DEPLOYMENT_PREFIX
+    required: true
+  - description: Active deadline seconds
+    name: ACTIVE_DEADLINE_SECONDS
+    required: true
+  - description: Docker registry
+    name: DOCKER_REGISTRY
+    required: true
+  - description: Tag of TeamCity image
+    name: TEAMCITY_IMAGE_TAG
+    required: true
+  - description: Service account name with SCC - anyuid
+    name: SERVICE_ACCOUNT_ANYUID
+    required: true
+  - description: TeamCity instance identifier
+    name: TEAMCITY_ID
+    required: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 pluginManagement {
     val releaseManagementVersion = extra["octopus-release-management.version"] as String
+    val ocTemplatePluginVersion = extra["octopus-oc-template.version"] as String
 
     plugins {
         id("org.jetbrains.kotlin.jvm") version ("1.9.20")
@@ -7,6 +8,7 @@ pluginManagement {
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
         id("org.octopusden.octopus-release-management") version(releaseManagementVersion)
+        id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
     }
 }
 

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -69,7 +69,7 @@ class ApplicationTest {
             "${TeamcityCreateBuildChainCommand.PARENT}=$TEST_PROJECT",
             "${TeamcityCreateBuildChainCommand.COMPONENT}=$componentName",
             "${TeamcityCreateBuildChainCommand.VERSION}=$minorVersion",
-            "${TeamcityCreateBuildChainCommand.CR}=$COMPONENTS_REGISTRY_SERVICE_URL",
+            "${TeamcityCreateBuildChainCommand.CR}=http://$hostComponentsRegistry",
             "${TeamcityCreateBuildChainCommand.CREATE_CHECKLIST}=$createChecklist",
             "${TeamcityCreateBuildChainCommand.CREATE_RC_FORCE}=$createRcForce",
         )
@@ -814,7 +814,12 @@ class ApplicationTest {
         const val TEAMCITY_USER = "admin"
         const val TEAMCITY_PASSWORD = "admin"
 
-        const val COMPONENTS_REGISTRY_SERVICE_URL = "http://localhost:4567"
+        private val hostTeamcity2022 = System.getProperty("test.teamcity-2022-host")
+            ?: throw Exception("System property 'test.teamcity-2022-host' must be defined")
+        private val hostTeamcity2025 = System.getProperty("test.teamcity-2025-host")
+            ?: throw Exception("System property 'test.teamcity-2025-host' must be defined")
+        private val hostComponentsRegistry = System.getProperty("test.components-registry-host")
+            ?: throw Exception("System property 'test.teamcity-2025-host' must be defined")
 
         private fun createClient(config: TeamcityTestConfiguration): TeamcityClassicClient {
             return TeamcityClassicClient(object : ClientParametersProvider {
@@ -833,12 +838,12 @@ class ApplicationTest {
         fun teamcityConfigurations(): List<TeamcityTestConfiguration> = listOf(
             TeamcityTestConfiguration(
                 name = "v22",
-                host = "http://localhost:8111",
+                host = "http://$hostTeamcity2022",
                 version = 2022
             ),
             TeamcityTestConfiguration(
                 name = "v25",
-                host = "http://localhost:8112",
+                host = "http://$hostTeamcity2025",
                 version = 2025
             )
         )


### PR DESCRIPTION
The following okd parameters have also been created:
```
okd.active-deadline-seconds=1800
okd.project=
okd.cluster-domain=
okd.web-console-url=
okd.service-account-anyuid=teamcity
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OKD support: templates for TeamCity servers, components registry, PVCs, and uploader; ocTemplate plugin/DSL and new Gradle tasks to prepare, copy and seed OKD instances.
  - Docker Compose: separate TeamCity 2022 and 2025 services with distinct data/log paths and healthchecks.
  - Dynamic default versioning computed from hostname when unspecified.

- **Tests**
  - Tests read service host addresses from system properties (per-platform).

- **Chores**
  - Centralized image tags, registries and OKD settings; signing requirement made configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->