### PR TITLE
  Cancel RC and Release builds when dependency fails instead of marking as failed to start.

### DIFF
--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
@@ -1,6 +1,5 @@
 package org.octopusden.octopus.automation.teamcity
 
 enum class DependencyFailureAction(val value: String) {
-    MAKE_FAILED_TO_START("MAKE_FAILED_TO_START"),
     CANCEL("CANCEL")
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
@@ -1,0 +1,6 @@
+package org.octopusden.octopus.automation.teamcity
+
+enum class DependencyFailureAction(val value: String) {
+    MAKE_FAILED_TO_START("MAKE_FAILED_TO_START"),
+    CANCEL("CANCEL")
+}

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -115,7 +115,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                         project.id
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
-                    addSnapshotDependency(checklistConfig, rcConfig, "CANCEL")
+                    addSnapshotDependency(checklistConfig, rcConfig, DependencyFailureAction.CANCEL)
                     setBuildTypeParameter(
                         checklistConfig.id,
                         "BUILD_VERSION",
@@ -130,8 +130,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
 
-                addSnapshotDependency(rcConfig, compileConfig, "CANCEL")
-                addSnapshotDependency(releaseConfig, rcConfig, "CANCEL")
+                addSnapshotDependency(rcConfig, compileConfig, DependencyFailureAction.CANCEL)
+                addSnapshotDependency(releaseConfig, rcConfig, DependencyFailureAction.CANCEL)
 
                 setBuildTypeParameter(rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
                 releaseConfig
@@ -142,7 +142,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                     project.id
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
-                addSnapshotDependency(releaseConfig, compileConfig, "CANCEL")
+                addSnapshotDependency(releaseConfig, compileConfig, DependencyFailureAction.CANCEL)
                 releaseConfig
             }
         disableBuildStep(releaseConfig.id, "IncrementTeamCityBuildConfigurationParameter")
@@ -175,7 +175,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private fun addSnapshotDependency(
         buildType: TeamcityBuildType,
         sourceBuildType: TeamcityBuildType,
-        onDependencyFailure: String
+        onDependencyFailure: DependencyFailureAction
     ) {
         client.createSnapshotDependency(
             buildType.id,
@@ -184,8 +184,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 type = "snapshot_dependency",
                 properties = TeamcityProperties(
                     listOf(
-                        TeamcityProperty("run-build-if-dependency-failed", onDependencyFailure),
-                        TeamcityProperty("run-build-if-dependency-failed-to-start", onDependencyFailure),
+                        TeamcityProperty("run-build-if-dependency-failed", onDependencyFailure.value),
+                        TeamcityProperty("run-build-if-dependency-failed-to-start", onDependencyFailure.value),
                         TeamcityProperty("run-build-on-the-same-agent", "false"),
                         TeamcityProperty("take-started-build-with-same-revisions", "true"),
                         TeamcityProperty("take-successful-builds-only", "true"),

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -130,8 +130,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
 
-                addSnapshotDependency(rcConfig, compileConfig)
-                addSnapshotDependency(releaseConfig, rcConfig)
+                addSnapshotDependency(rcConfig, compileConfig, "CANCEL")
+                addSnapshotDependency(releaseConfig, rcConfig, "CANCEL")
 
                 setBuildTypeParameter(rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
                 releaseConfig
@@ -142,7 +142,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                     project.id
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
-                addSnapshotDependency(releaseConfig, compileConfig)
+                addSnapshotDependency(releaseConfig, compileConfig, "CANCEL")
                 releaseConfig
             }
         disableBuildStep(releaseConfig.id, "IncrementTeamCityBuildConfigurationParameter")
@@ -172,7 +172,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             )
         )
 
-    private fun addSnapshotDependency(buildType: TeamcityBuildType, sourceBuildType: TeamcityBuildType) {
+    private fun addSnapshotDependency(
+        buildType: TeamcityBuildType,
+        sourceBuildType: TeamcityBuildType,
+        onDependencyFailure: String = "MAKE_FAILED_TO_START"
+    ) {
         client.createSnapshotDependency(
             buildType.id,
             TeamcitySnapshotDependency(
@@ -180,7 +184,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 type = "snapshot_dependency",
                 properties = TeamcityProperties(
                     listOf(
-                        TeamcityProperty("run-build-if-dependency-failed", "MAKE_FAILED_TO_START"),
+                        TeamcityProperty("run-build-if-dependency-failed", onDependencyFailure),
                         TeamcityProperty("run-build-if-dependency-failed-to-start", "MAKE_FAILED_TO_START"),
                         TeamcityProperty("run-build-on-the-same-agent", "false"),
                         TeamcityProperty("take-started-build-with-same-revisions", "true"),

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -115,7 +115,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                         project.id
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
-                    addSnapshotDependency(checklistConfig, rcConfig)
+                    addSnapshotDependency(checklistConfig, rcConfig, "MAKE_FAILED_TO_START")
                     setBuildTypeParameter(
                         checklistConfig.id,
                         "BUILD_VERSION",
@@ -175,7 +175,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private fun addSnapshotDependency(
         buildType: TeamcityBuildType,
         sourceBuildType: TeamcityBuildType,
-        onDependencyFailure: String = "MAKE_FAILED_TO_START"
+        onDependencyFailure: String
     ) {
         client.createSnapshotDependency(
             buildType.id,

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -115,7 +115,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                         project.id
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
-                    addSnapshotDependency(checklistConfig, rcConfig, "MAKE_FAILED_TO_START")
+                    addSnapshotDependency(checklistConfig, rcConfig, "CANCEL")
                     setBuildTypeParameter(
                         checklistConfig.id,
                         "BUILD_VERSION",
@@ -185,7 +185,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 properties = TeamcityProperties(
                     listOf(
                         TeamcityProperty("run-build-if-dependency-failed", onDependencyFailure),
-                        TeamcityProperty("run-build-if-dependency-failed-to-start", "MAKE_FAILED_TO_START"),
+                        TeamcityProperty("run-build-if-dependency-failed-to-start", onDependencyFailure),
                         TeamcityProperty("run-build-on-the-same-agent", "false"),
                         TeamcityProperty("take-started-build-with-same-revisions", "true"),
                         TeamcityProperty("take-successful-builds-only", "true"),

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInfo
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.octopusden.octopus.automation.teamcity.DependencyFailureAction
 import org.octopusden.octopus.automation.teamcity.TeamcityCommand
 import org.octopusden.octopus.automation.teamcity.TeamcityCreateBuildChainCommand
 import org.octopusden.octopus.automation.teamcity.TeamcityGetBuildTypesAgentRequirementsCommand
@@ -236,9 +237,9 @@ class ApplicationTest {
             }
         }
 
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
-        validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, "CANCEL")
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
 
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
@@ -297,8 +298,8 @@ class ApplicationTest {
             }
         }
 
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
 
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
@@ -382,7 +383,7 @@ class ApplicationTest {
                 }
             }
 
-            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
 
             val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
             Assertions.assertEquals(2, buildSteps.size)
@@ -447,8 +448,8 @@ class ApplicationTest {
             }
         }
 
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
 
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
@@ -794,17 +795,17 @@ class ApplicationTest {
     private fun validateSnapshotDependencyFailureAction(
         teamcityClient: TeamcityClassicClient,
         buildTypeId: String,
-        expectedAction: String
+        expectedAction: DependencyFailureAction
     ) {
         val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypeId).snapshotDependencies
         Assertions.assertEquals(1, snapshotDependencies.size)
         val properties = snapshotDependencies[0].properties.properties.associate { it.name to it.value }
         Assertions.assertEquals(
-            expectedAction, properties["run-build-if-dependency-failed"],
+            expectedAction.value, properties["run-build-if-dependency-failed"],
             "run-build-if-dependency-failed for $buildTypeId"
         )
         Assertions.assertEquals(
-            expectedAction, properties["run-build-if-dependency-failed-to-start"],
+            expectedAction.value, properties["run-build-if-dependency-failed-to-start"],
             "run-build-if-dependency-failed-to-start for $buildTypeId"
         )
     }

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -236,6 +236,10 @@ class ApplicationTest {
             }
         }
 
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
         Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
@@ -292,6 +296,9 @@ class ApplicationTest {
                 Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
             }
         }
+
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
 
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
@@ -375,6 +382,8 @@ class ApplicationTest {
                 }
             }
 
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
+
             val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
             Assertions.assertEquals(2, buildSteps.size)
             Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
@@ -437,6 +446,9 @@ class ApplicationTest {
                 Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
             }
         }
+
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, "CANCEL")
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, "CANCEL")
 
         val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
         Assertions.assertEquals(2, buildSteps.size)
@@ -777,6 +789,24 @@ class ApplicationTest {
                 )
             )
         }
+    }
+
+    private fun validateSnapshotDependencyFailureAction(
+        teamcityClient: TeamcityClassicClient,
+        buildTypeId: String,
+        expectedAction: String
+    ) {
+        val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypeId).snapshotDependencies
+        Assertions.assertEquals(1, snapshotDependencies.size)
+        val properties = snapshotDependencies[0].properties.properties.associate { it.name to it.value }
+        Assertions.assertEquals(
+            expectedAction, properties["run-build-if-dependency-failed"],
+            "run-build-if-dependency-failed for $buildTypeId"
+        )
+        Assertions.assertEquals(
+            expectedAction, properties["run-build-if-dependency-failed-to-start"],
+            "run-build-if-dependency-failed-to-start for $buildTypeId"
+        )
     }
 
     private fun validateBuildTypeTemplate(teamcityClient: TeamcityClassicClient, buildTypeId: String, templateId: String) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Snapshot dependencies now accept an explicit failure-handling option so dependency failures can be handled predictably.
  * Key build configurations have been updated to use the CANCEL failure policy for consistent build-chain behavior.

* **Tests**
  * Added tests to validate snapshot-dependency failure handling across relevant build configurations and scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->