### PR TITLE
Grant Admin permission to component owner and release manager when cr…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-teamcity-client.version=2.0.71
+teamcity-client.version=2.0.84
 octopus-components-registry-service.version=2.0.59
 octopus-release-management.version=2.0.28
 octopus-oc-template.version=2.0.4

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -151,8 +151,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         setBuildTypeParameter(releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
         setProjectParameter(project.id, "COMPONENT_NAME", componentName)
         setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)
-        assignProjectAdminRoleToUser(project.id, component.componentOwner)
-        component.releaseManager?.let { assignProjectAdminRoleToUser(project.id, it) }
+        listOfNotNull(component.componentOwner, component.releaseManager)
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .distinct()
+            .forEach { assignProjectAdminRoleToUser(project.id, it) }
     }
 
     private fun attachVcsRootToBuildType(buildTypeId: String, vcsRootId: String?) =
@@ -179,7 +182,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         client.createSnapshotDependency(
             buildType.id,
             TeamcitySnapshotDependency(
-                id = sourceBuildType.name!!,
+                id = requireNotNull(sourceBuildType.name) { "Build type name is null for ${sourceBuildType.id}" },
                 type = "snapshot_dependency",
                 properties = TeamcityProperties(
                     listOf(

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -10,6 +10,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponent
 import org.octopusden.octopus.components.registry.core.dto.RepositoryType
+import feign.FeignException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
 import org.octopusden.octopus.infrastructure.teamcity.client.getProject
 import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
@@ -213,8 +214,12 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         }
 
     private fun assignProjectAdminRoleToUser(projectId: String, username: String) {
-        client.assignProjectRoleToUser(username, TeamcityRole.PROJECT_ADMIN, projectId)
-        log.info("Assigned PROJECT_ADMIN role to user $username for project $projectId")
+        try {
+            client.assignProjectRoleToUser(username, TeamcityRole.PROJECT_ADMIN, projectId)
+            log.info("Assigned PROJECT_ADMIN role to user $username for project $projectId")
+        } catch (e: FeignException.NotFound) {
+            log.warn("Failed to assign PROJECT_ADMIN role to user '{}' for project '{}': user not found in TeamCity", username, projectId)
+        }
     }
 
     private fun disableBuildStep(buildTypeId: String, stepNameOrType: String, disable: Boolean = true) {

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -15,6 +15,7 @@ import org.octopusden.octopus.infrastructure.teamcity.client.getProject
 import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
 import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClientUrlProvider
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
+import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityRole
 import org.octopusden.octopus.infrastructure.teamcity.client.ConfigurationType
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityVCSType
 import org.octopusden.octopus.infrastructure.teamcity.client.disableBuildStep
@@ -150,6 +151,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         setBuildTypeParameter(releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
         setProjectParameter(project.id, "COMPONENT_NAME", componentName)
         setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)
+        assignProjectAdminRoleToUser(project.id, component.componentOwner)
+        component.releaseManager?.let { assignProjectAdminRoleToUser(project.id, it) }
     }
 
     private fun attachVcsRootToBuildType(buildTypeId: String, vcsRootId: String?) =
@@ -176,7 +179,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         client.createSnapshotDependency(
             buildType.id,
             TeamcitySnapshotDependency(
-                id = sourceBuildType.name,
+                id = sourceBuildType.name!!,
                 type = "snapshot_dependency",
                 properties = TeamcityProperties(
                     listOf(
@@ -201,6 +204,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         client.setParameter(ConfigurationType.PROJECT, projectId, name, value).also {
             log.info("Set parameter $name value $value for project with id $projectId")
         }
+
+    private fun assignProjectAdminRoleToUser(projectId: String, username: String) {
+        client.assignProjectRoleToUser(username, TeamcityRole.PROJECT_ADMIN, projectId)
+        log.info("Assigned PROJECT_ADMIN role to user $username for project $projectId")
+    }
 
     private fun disableBuildStep(buildTypeId: String, stepNameOrType: String, disable: Boolean = true) {
         client.getBuildSteps(buildTypeId)

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
@@ -78,7 +78,10 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
 
         index.byBuildType.forEach { (buildTypeLocator, entriesToDetach) ->
             val buildType = client.getBuildType(buildTypeLocator)
-            val projectId = buildType.projectId!!
+            val projectId = requireNotNull(buildType.projectId) {
+                "Build type ${buildType.id} ('${buildType.name}') has no projectId; cannot replace VCS roots"
+            }
+
             val branch = extractBranchFromBuildType(buildType)
             val newVcs = findOrCreateGitVcsRootInProject(projectId, newVcsRoot, branch)
 

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
@@ -78,7 +78,7 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
 
         index.byBuildType.forEach { (buildTypeLocator, entriesToDetach) ->
             val buildType = client.getBuildType(buildTypeLocator)
-            val projectId = buildType.projectId
+            val projectId = buildType.projectId!!
             val branch = extractBranchFromBuildType(buildType)
             val newVcs = findOrCreateGitVcsRootInProject(projectId, newVcsRoot, branch)
 

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -865,7 +865,7 @@ class ApplicationTest {
     }
 
     private fun createTestUser(host: String, username: String) {
-        HttpClient.newHttpClient().send(
+        val response = HttpClient.newHttpClient().send(
             HttpRequest.newBuilder()
                 .uri(URI("$host/app/rest/users"))
                 .header("Content-Type", "application/json")
@@ -877,6 +877,11 @@ class ApplicationTest {
                 .POST(HttpRequest.BodyPublishers.ofString("""{"username":"$username","password":"$username"}"""))
                 .build(),
             HttpResponse.BodyHandlers.ofString()
+        )
+        val status = response.statusCode()
+        Assertions.assertTrue(
+            status in 200..299 || status == 400,
+            "Failed to create user '$username': HTTP $status - ${response.body()}"
         )
     }
 

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -203,59 +203,62 @@ class ApplicationTest {
         val minorVersion = "1.0"
         val componentName = "ee-component"
 
+        val projectId = "TestTeamcityAutomation_EeComponent"
         Assertions.assertEquals(
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
         )
 
-        val projectId = "TestTeamcityAutomation_EeComponent"
-        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-        Assertions.assertEquals(4, buildTypes.size)
+        try {
+            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+            Assertions.assertEquals(4, buildTypes.size)
 
-        val compileConfigId = "${projectId}_10CompileUtAuto"
-        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-        val checklistConfigId = "${projectId}_30ReleaseChecklistValidationManual"
-        val releaseConfigId = "${projectId}_40ReleaseManual"
+            val compileConfigId = "${projectId}_10CompileUtAuto"
+            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+            val checklistConfigId = "${projectId}_30ReleaseChecklistValidationManual"
+            val releaseConfigId = "${projectId}_40ReleaseManual"
 
-        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-        validateBuildTypeTemplate(teamcityClient, checklistConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_CHECKLIST)
-        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+            validateBuildTypeTemplate(teamcityClient, checklistConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_CHECKLIST)
+            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-        val buildTypesIdAndDependencyId = mapOf(
-            compileConfigId to null,
-            rcConfigId to compileConfigId,
-            checklistConfigId to rcConfigId,
-            releaseConfigId to rcConfigId
-        )
+            val buildTypesIdAndDependencyId = mapOf(
+                compileConfigId to null,
+                rcConfigId to compileConfigId,
+                checklistConfigId to rcConfigId,
+                releaseConfigId to rcConfigId
+            )
 
-        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-            dependencyId?.let {
-                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                Assertions.assertEquals(1, snapshotDependencies.size)
-                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+                dependencyId?.let {
+                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                    Assertions.assertEquals(1, snapshotDependencies.size)
+                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+                }
             }
+
+            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+            validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, DependencyFailureAction.CANCEL)
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+            Assertions.assertEquals(2, buildSteps.size)
+            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
+            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
+            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+
+            Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+
+            Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
+            Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
+        } finally {
+            teamcityClient.deleteProject(projectId)
         }
-
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-        validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, DependencyFailureAction.CANCEL)
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-        Assertions.assertEquals(2, buildSteps.size)
-        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
-        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
-        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-
-        Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
-
-        Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
-        Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
-        teamcityClient.deleteProject(projectId)
     }
 
     @ParameterizedTest
@@ -271,11 +274,31 @@ class ApplicationTest {
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
         )
 
-        val roles = getUserRoles(config.host, TEST_USER)
-        val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
-        Assertions.assertTrue(hasProjectAdmin, "User '$TEST_USER' should have PROJECT_ADMIN role on project '$projectId'")
+        try {
+            val roles = getUserRoles(config.host, TEST_USER)
+            val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
+            Assertions.assertTrue(hasProjectAdmin, "User '$TEST_USER' should have PROJECT_ADMIN role on project '$projectId'")
+        } finally {
+            teamcityClient.deleteProject(projectId)
+        }
+    }
 
-        teamcityClient.deleteProject(projectId)
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testTeamCityCreateBuildChainWithNonExistentUser(config: TeamcityTestConfiguration) {
+        val teamcityClient = createClient(config)
+        cleanUpResources(teamcityClient, config)
+
+        val componentName = "nonexistent-user-component"
+        val projectId = "TestTeamcityAutomation_NonexistentUserComponent"
+
+        try {
+            Assertions.assertEquals(
+                0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+            )
+        } finally {
+            teamcityClient.deleteProject(projectId)
+        }
     }
 
     @ParameterizedTest
@@ -287,69 +310,72 @@ class ApplicationTest {
         val minorVersion = "1.0"
         val componentName = "ee-component"
 
+        val projectId = "TestTeamcityAutomation_EeComponent"
         Assertions.assertEquals(
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion, false)
         )
 
-        val projectId = "TestTeamcityAutomation_EeComponent"
-        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-        Assertions.assertEquals(3, buildTypes.size)
+        try {
+            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+            Assertions.assertEquals(3, buildTypes.size)
 
-        val compileConfigId = "${projectId}_10CompileUtAuto"
-        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-        val releaseConfigId = "${projectId}_30ReleaseManual"
+            val compileConfigId = "${projectId}_10CompileUtAuto"
+            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+            val releaseConfigId = "${projectId}_30ReleaseManual"
 
-        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-        val buildTypesIdAndDependencyId = mapOf(
-            compileConfigId to null,
-            rcConfigId to compileConfigId,
-            releaseConfigId to rcConfigId
-        )
+            val buildTypesIdAndDependencyId = mapOf(
+                compileConfigId to null,
+                rcConfigId to compileConfigId,
+                releaseConfigId to rcConfigId
+            )
 
-        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-            dependencyId?.let {
-                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                Assertions.assertEquals(1, snapshotDependencies.size)
-                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+                dependencyId?.let {
+                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                    Assertions.assertEquals(1, snapshotDependencies.size)
+                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+                }
             }
+
+            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+            Assertions.assertEquals(2, buildSteps.size)
+            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+            Assertions.assertEquals(
+                compileBuildVersion,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
+            )
+            Assertions.assertEquals(
+                compileBuildVersion,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+            )
+
+            Assertions.assertEquals(
+                compileConfigId,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+            )
+
+            Assertions.assertEquals(
+                componentName,
+                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+            )
+            Assertions.assertEquals(
+                minorVersion,
+                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+            )
+        } finally {
+            teamcityClient.deleteProject(projectId)
         }
-
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-        Assertions.assertEquals(2, buildSteps.size)
-        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-        Assertions.assertEquals(
-            compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
-        )
-        Assertions.assertEquals(
-            compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
-        )
-
-        Assertions.assertEquals(
-            compileConfigId,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
-        )
-
-        Assertions.assertEquals(
-            componentName,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
-        )
-        Assertions.assertEquals(
-            minorVersion,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
-        )
-        teamcityClient.deleteProject(projectId)
     }
 
     /**
@@ -380,44 +406,47 @@ class ApplicationTest {
                 0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
             )
 
-            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-            Assertions.assertEquals(2, buildTypes.size)
+            try {
+                Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+                val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+                Assertions.assertEquals(2, buildTypes.size)
 
-            val compileConfigId = "${projectId}_10CompileUtAuto"
-            val releaseConfigId = "${projectId}_20ReleaseManual"
+                val compileConfigId = "${projectId}_10CompileUtAuto"
+                val releaseConfigId = "${projectId}_20ReleaseManual"
 
-            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+                validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-            val buildTypesIdAndDependencyId = mapOf(
-                compileConfigId to null,
-                releaseConfigId to compileConfigId
-            )
+                val buildTypesIdAndDependencyId = mapOf(
+                    compileConfigId to null,
+                    releaseConfigId to compileConfigId
+                )
 
-            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-                dependencyId?.let {
-                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                    Assertions.assertEquals(1, snapshotDependencies.size)
-                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+                buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+                    Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+                    Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+                    dependencyId?.let {
+                        val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                        Assertions.assertEquals(1, snapshotDependencies.size)
+                        Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+                    }
                 }
+
+                validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+                val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+                Assertions.assertEquals(2, buildSteps.size)
+                Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+                val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+                Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+
+                Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+
+                Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
+                Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
+            } finally {
+                teamcityClient.deleteProject(projectId)
             }
-
-            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-            Assertions.assertEquals(2, buildSteps.size)
-            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-
-            Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
-
-            Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
-            Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
-            teamcityClient.deleteProject(projectId)
         }
     }
 
@@ -442,60 +471,63 @@ class ApplicationTest {
             )
         )
 
-        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-        Assertions.assertEquals(3, buildTypes.size)
+        try {
+            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+            Assertions.assertEquals(3, buildTypes.size)
 
-        val compileConfigId = "${projectId}_10CompileUtAuto"
-        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-        val releaseConfigId = "${projectId}_30ReleaseManual"
+            val compileConfigId = "${projectId}_10CompileUtAuto"
+            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+            val releaseConfigId = "${projectId}_30ReleaseManual"
 
-        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-        val buildTypesIdAndDependencyId = mapOf(
-            compileConfigId to null,
-            rcConfigId to compileConfigId,
-            releaseConfigId to rcConfigId
-        )
+            val buildTypesIdAndDependencyId = mapOf(
+                compileConfigId to null,
+                rcConfigId to compileConfigId,
+                releaseConfigId to rcConfigId
+            )
 
-        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-            dependencyId?.let {
-                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                Assertions.assertEquals(1, snapshotDependencies.size)
-                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+                dependencyId?.let {
+                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                    Assertions.assertEquals(1, snapshotDependencies.size)
+                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
+                }
             }
+
+            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+            Assertions.assertEquals(2, buildSteps.size)
+            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+            Assertions.assertEquals(
+                compileBuildVersion,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+            )
+
+            Assertions.assertEquals(
+                compileConfigId,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+            )
+
+            Assertions.assertEquals(
+                componentName,
+                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+            )
+            Assertions.assertEquals(
+                minorVersion,
+                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+            )
+        } finally {
+            teamcityClient.deleteProject(projectId)
         }
-
-        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-        Assertions.assertEquals(2, buildSteps.size)
-        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-        Assertions.assertEquals(
-            compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
-        )
-
-        Assertions.assertEquals(
-            compileConfigId,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
-        )
-
-        Assertions.assertEquals(
-            componentName,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
-        )
-        Assertions.assertEquals(
-            minorVersion,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
-        )
-        teamcityClient.deleteProject(projectId)
     }
 
     /**

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -208,57 +208,53 @@ class ApplicationTest {
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
         )
 
-        try {
-            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-            Assertions.assertEquals(4, buildTypes.size)
+        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+        Assertions.assertEquals(4, buildTypes.size)
 
-            val compileConfigId = "${projectId}_10CompileUtAuto"
-            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-            val checklistConfigId = "${projectId}_30ReleaseChecklistValidationManual"
-            val releaseConfigId = "${projectId}_40ReleaseManual"
+        val compileConfigId = "${projectId}_10CompileUtAuto"
+        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+        val checklistConfigId = "${projectId}_30ReleaseChecklistValidationManual"
+        val releaseConfigId = "${projectId}_40ReleaseManual"
 
-            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-            validateBuildTypeTemplate(teamcityClient, checklistConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_CHECKLIST)
-            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+        validateBuildTypeTemplate(teamcityClient, checklistConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_CHECKLIST)
+        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-            val buildTypesIdAndDependencyId = mapOf(
-                compileConfigId to null,
-                rcConfigId to compileConfigId,
-                checklistConfigId to rcConfigId,
-                releaseConfigId to rcConfigId
-            )
+        val buildTypesIdAndDependencyId = mapOf(
+            compileConfigId to null,
+            rcConfigId to compileConfigId,
+            checklistConfigId to rcConfigId,
+            releaseConfigId to rcConfigId
+        )
 
-            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-                dependencyId?.let {
-                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                    Assertions.assertEquals(1, snapshotDependencies.size)
-                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
-                }
+        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+            dependencyId?.let {
+                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                Assertions.assertEquals(1, snapshotDependencies.size)
+                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
             }
-
-            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-            validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, DependencyFailureAction.CANCEL)
-            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-            Assertions.assertEquals(2, buildSteps.size)
-            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
-            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
-            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-
-            Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
-
-            Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
-            Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
-        } finally {
-            teamcityClient.deleteProject(projectId)
         }
+
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, checklistConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+        Assertions.assertEquals(2, buildSteps.size)
+        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
+        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
+        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+
+        Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+
+        Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
+        Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
     }
 
     @ParameterizedTest
@@ -274,13 +270,9 @@ class ApplicationTest {
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
         )
 
-        try {
-            val roles = getUserRoles(config.host, TEST_USER)
-            val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
-            Assertions.assertTrue(hasProjectAdmin, "User '$TEST_USER' should have PROJECT_ADMIN role on project '$projectId'")
-        } finally {
-            teamcityClient.deleteProject(projectId)
-        }
+        val roles = getUserRoles(config.host, TEST_USER)
+        val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
+        Assertions.assertTrue(hasProjectAdmin, "User '$TEST_USER' should have PROJECT_ADMIN role on project '$projectId'")
     }
 
     @ParameterizedTest
@@ -292,13 +284,9 @@ class ApplicationTest {
         val componentName = "nonexistent-user-component"
         val projectId = "TestTeamcityAutomation_NonexistentUserComponent"
 
-        try {
-            Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
-            )
-        } finally {
-            teamcityClient.deleteProject(projectId)
-        }
+        Assertions.assertEquals(
+            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+        )
     }
 
     @ParameterizedTest
@@ -315,67 +303,63 @@ class ApplicationTest {
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion, false)
         )
 
-        try {
-            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-            Assertions.assertEquals(3, buildTypes.size)
+        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+        Assertions.assertEquals(3, buildTypes.size)
 
-            val compileConfigId = "${projectId}_10CompileUtAuto"
-            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-            val releaseConfigId = "${projectId}_30ReleaseManual"
+        val compileConfigId = "${projectId}_10CompileUtAuto"
+        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+        val releaseConfigId = "${projectId}_30ReleaseManual"
 
-            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-            val buildTypesIdAndDependencyId = mapOf(
-                compileConfigId to null,
-                rcConfigId to compileConfigId,
-                releaseConfigId to rcConfigId
-            )
+        val buildTypesIdAndDependencyId = mapOf(
+            compileConfigId to null,
+            rcConfigId to compileConfigId,
+            releaseConfigId to rcConfigId
+        )
 
-            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-                dependencyId?.let {
-                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                    Assertions.assertEquals(1, snapshotDependencies.size)
-                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
-                }
+        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+            dependencyId?.let {
+                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                Assertions.assertEquals(1, snapshotDependencies.size)
+                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
             }
-
-            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-            Assertions.assertEquals(2, buildSteps.size)
-            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-            Assertions.assertEquals(
-                compileBuildVersion,
-                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
-            )
-            Assertions.assertEquals(
-                compileBuildVersion,
-                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
-            )
-
-            Assertions.assertEquals(
-                compileConfigId,
-                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
-            )
-
-            Assertions.assertEquals(
-                componentName,
-                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
-            )
-            Assertions.assertEquals(
-                minorVersion,
-                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
-            )
-        } finally {
-            teamcityClient.deleteProject(projectId)
         }
+
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+        Assertions.assertEquals(2, buildSteps.size)
+        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
+        )
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+        )
+
+        Assertions.assertEquals(
+            compileConfigId,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+        )
+
+        Assertions.assertEquals(
+            componentName,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+        )
+        Assertions.assertEquals(
+            minorVersion,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+        )
     }
 
     /**
@@ -406,47 +390,43 @@ class ApplicationTest {
                 0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
             )
 
-            try {
-                Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-                val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-                Assertions.assertEquals(2, buildTypes.size)
+            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+            Assertions.assertEquals(2, buildTypes.size)
 
-                val compileConfigId = "${projectId}_10CompileUtAuto"
-                val releaseConfigId = "${projectId}_20ReleaseManual"
+            val compileConfigId = "${projectId}_10CompileUtAuto"
+            val releaseConfigId = "${projectId}_20ReleaseManual"
 
-                validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-                val buildTypesIdAndDependencyId = mapOf(
-                    compileConfigId to null,
-                    releaseConfigId to compileConfigId
-                )
+            val buildTypesIdAndDependencyId = mapOf(
+                compileConfigId to null,
+                releaseConfigId to compileConfigId
+            )
 
-                buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-                    Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-                    Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-                    dependencyId?.let {
-                        val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                        Assertions.assertEquals(1, snapshotDependencies.size)
-                        Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
-                    }
+            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+                dependencyId?.let {
+                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                    Assertions.assertEquals(1, snapshotDependencies.size)
+                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
                 }
-
-                validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-                val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-                Assertions.assertEquals(2, buildSteps.size)
-                Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-                val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-                Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
-
-                Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
-
-                Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
-                Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
-            } finally {
-                teamcityClient.deleteProject(projectId)
             }
+
+            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+            Assertions.assertEquals(2, buildSteps.size)
+            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+
+            Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+
+            Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
+            Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
         }
     }
 
@@ -471,63 +451,59 @@ class ApplicationTest {
             )
         )
 
-        try {
-            Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
-            val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
-            Assertions.assertEquals(3, buildTypes.size)
+        Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
+        val buildTypes = teamcityClient.getBuildTypes(projectId).buildTypes
+        Assertions.assertEquals(3, buildTypes.size)
 
-            val compileConfigId = "${projectId}_10CompileUtAuto"
-            val rcConfigId = "${projectId}_20ReleaseCandidateManual"
-            val releaseConfigId = "${projectId}_30ReleaseManual"
+        val compileConfigId = "${projectId}_10CompileUtAuto"
+        val rcConfigId = "${projectId}_20ReleaseCandidateManual"
+        val releaseConfigId = "${projectId}_30ReleaseManual"
 
-            validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
-            validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
+        validateBuildTypeTemplate(teamcityClient, rcConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RC)
+        validateBuildTypeTemplate(teamcityClient, releaseConfigId, TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE)
 
-            val buildTypesIdAndDependencyId = mapOf(
-                compileConfigId to null,
-                rcConfigId to compileConfigId,
-                releaseConfigId to rcConfigId
-            )
+        val buildTypesIdAndDependencyId = mapOf(
+            compileConfigId to null,
+            rcConfigId to compileConfigId,
+            releaseConfigId to rcConfigId
+        )
 
-            buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
-                Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
-                Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
-                dependencyId?.let {
-                    val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
-                    Assertions.assertEquals(1, snapshotDependencies.size)
-                    Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
-                }
+        buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
+            Assertions.assertNotNull(buildTypes.find { it.id == buildTypesId })
+            Assertions.assertEquals(1, teamcityClient.getBuildTypeVcsRootEntries(buildTypesId).entries.size)
+            dependencyId?.let {
+                val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypesId).snapshotDependencies
+                Assertions.assertEquals(1, snapshotDependencies.size)
+                Assertions.assertEquals(dependencyId, snapshotDependencies.get(0).sourceBuildType.id)
             }
-
-            validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
-            validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
-
-            val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
-            Assertions.assertEquals(2, buildSteps.size)
-            Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
-
-            val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-            Assertions.assertEquals(
-                compileBuildVersion,
-                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
-            )
-
-            Assertions.assertEquals(
-                compileConfigId,
-                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
-            )
-
-            Assertions.assertEquals(
-                componentName,
-                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
-            )
-            Assertions.assertEquals(
-                minorVersion,
-                teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
-            )
-        } finally {
-            teamcityClient.deleteProject(projectId)
         }
+
+        validateSnapshotDependencyFailureAction(teamcityClient, rcConfigId, DependencyFailureAction.CANCEL)
+        validateSnapshotDependencyFailureAction(teamcityClient, releaseConfigId, DependencyFailureAction.CANCEL)
+
+        val buildSteps = teamcityClient.getBuildSteps(releaseConfigId).steps
+        Assertions.assertEquals(2, buildSteps.size)
+        Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
+
+        val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+        )
+
+        Assertions.assertEquals(
+            compileConfigId,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+        )
+
+        Assertions.assertEquals(
+            componentName,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+        )
+        Assertions.assertEquals(
+            minorVersion,
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+        )
     }
 
     /**

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -81,7 +81,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityUpdateParameterSet(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val parameter = "TEST_PARAMETER"
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter, "OLD")
@@ -133,7 +133,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityUpdateParameterIncrement(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val parameter = "TEST_PARAMETER"
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter, "1.0")
@@ -197,7 +197,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForEEComponent(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val minorVersion = "1.0"
         val componentName = "ee-component"
@@ -257,7 +257,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainGrantsProjectAdminRole(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val componentName = "ee-component"
         val projectId = "TestTeamcityAutomation_EeComponent"
@@ -266,9 +266,9 @@ class ApplicationTest {
             0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
         )
 
-        val roles = getUserRoles(config.host, TEAMCITY_USER)
+        val roles = getUserRoles(config.host, TEST_USER)
         val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
-        Assertions.assertTrue(hasProjectAdmin, "User '$TEAMCITY_USER' should have PROJECT_ADMIN role on project '$projectId'")
+        Assertions.assertTrue(hasProjectAdmin, "User '$TEST_USER' should have PROJECT_ADMIN role on project '$projectId'")
 
         teamcityClient.deleteProject(projectId)
     }
@@ -277,7 +277,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForEEComponentWithoutCheckList(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val minorVersion = "1.0"
         val componentName = "ee-component"
@@ -358,7 +358,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForNonEEComponent(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val minorVersion = "1.0"
         val componentNamesToProjectId = mapOf(
@@ -415,7 +415,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForIEComponentWithRc(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val minorVersion = "1.0"
         val projectId = "TestTeamcityAutomation_IeComponent"
@@ -492,7 +492,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForJDKVersion(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val defaultJDKComponentName = "default-jdk-component"
         val defaultJDKProjectId = "TestTeamcityAutomation_DefaultJdkComponent"
@@ -533,7 +533,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityCreateBuildChainForCompileTemplate(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val componentNames = listOf("maven-component", "gradle-component", "provided-component", "in-container-component")
 
@@ -557,7 +557,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityUpdateParameterIncrementCurrent(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val parameter = "TEST_PARAMETER"
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter, "1.0")
@@ -601,7 +601,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityUploadMetarunners(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val metarunners = ApplicationTest::class.java.getResource("metarunners.zip")!!
         Assertions.assertEquals(
@@ -639,7 +639,7 @@ class ApplicationTest {
     @MethodSource("teamcityContexts")
     fun testTeamCityReplaceVcsRoot(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
-        cleanUpResources(teamcityClient)
+        cleanUpResources(teamcityClient, config)
 
         val oldUrl = "ssh://git@example.org/old/repository.git"
         val newUrl = "ssh://git@example.org/new/repository.git"
@@ -704,12 +704,13 @@ class ApplicationTest {
         this.testInfo = testInfo
     }
 
-    private fun cleanUpResources(teamcityClient: TeamcityClassicClient) {
+    private fun cleanUpResources(teamcityClient: TeamcityClassicClient, config: TeamcityTestConfiguration) {
         try {
             teamcityClient.deleteProject(TEST_PROJECT)
         } catch (e: Exception) {
             //do nothing
         }
+        createTestUser(config.host, TEST_USER)
         teamcityClient.createProject(
             TeamcityCreateProject(
                 TEST_PROJECT, TEST_PROJECT, TeamcityLinkProject("RDDepartment")
@@ -800,6 +801,22 @@ class ApplicationTest {
         }
     }
 
+    private fun createTestUser(host: String, username: String) {
+        HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder()
+                .uri(URI("$host/app/rest/users"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header(
+                    "Authorization",
+                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}"
+                )
+                .POST(HttpRequest.BodyPublishers.ofString("""{"username":"$username","password":"$username"}"""))
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        )
+    }
+
     private data class RoleEntry(val roleId: String, val scope: String)
 
     private fun getUserRoles(host: String, username: String): List<RoleEntry> {
@@ -875,6 +892,7 @@ class ApplicationTest {
 
         const val TEAMCITY_USER = "admin"
         const val TEAMCITY_PASSWORD = "admin"
+        const val TEST_USER = "testuser"
 
         private val hostTeamcity2022 = System.getProperty("test.teamcity-2022-host")
             ?: throw Exception("System property 'test.teamcity-2022-host' must be defined")

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -6,6 +6,7 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.util.Base64
 import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions
@@ -249,6 +250,26 @@ class ApplicationTest {
 
         Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
         Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
+        teamcityClient.deleteProject(projectId)
+    }
+
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testTeamCityCreateBuildChainGrantsProjectAdminRole(config: TeamcityTestConfiguration) {
+        val teamcityClient = createClient(config)
+        cleanUpResources(teamcityClient)
+
+        val componentName = "ee-component"
+        val projectId = "TestTeamcityAutomation_EeComponent"
+
+        Assertions.assertEquals(
+            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+        )
+
+        val roles = getUserRoles(config.host, TEAMCITY_USER)
+        val hasProjectAdmin = roles.any { it.roleId == "PROJECT_ADMIN" && it.scope == "p:$projectId" }
+        Assertions.assertTrue(hasProjectAdmin, "User '$TEAMCITY_USER' should have PROJECT_ADMIN role on project '$projectId'")
+
         teamcityClient.deleteProject(projectId)
     }
 
@@ -777,6 +798,31 @@ class ApplicationTest {
                 )
             )
         }
+    }
+
+    private data class RoleEntry(val roleId: String, val scope: String)
+
+    private fun getUserRoles(host: String, username: String): List<RoleEntry> {
+        val response = HttpClient.newHttpClient().send(
+            HttpRequest.newBuilder()
+                .uri(URI("$host/app/rest/users/username:$username/roles"))
+                .header("Accept", "application/json")
+                .header(
+                    "Authorization",
+                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}"
+                )
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString()
+        )
+        Assertions.assertEquals(200, response.statusCode(), "Failed to get roles for user '$username'")
+        val tree = ObjectMapper().readTree(response.body())
+        return tree["role"]?.map { node ->
+            RoleEntry(
+                roleId = node["roleId"].asText(),
+                scope = node["scope"].asText()
+            )
+        } ?: emptyList()
     }
 
     private fun validateBuildTypeTemplate(teamcityClient: TeamcityClassicClient, buildTypeId: String, templateId: String) {

--- a/src/test/resources/components-registry/TestComponents.groovy
+++ b/src/test/resources/components-registry/TestComponents.groovy
@@ -139,3 +139,14 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
         javaVersion = "11"
     }
 }
+
+"nonexistent-user-component" {
+    componentDisplayName = "Nonexistent User Component"
+    componentOwner = "nonexistentuser"
+    releaseManager = "nonexistentuser"
+    groupId = "corp.domain"
+    vcsUrl = "ssh://git@git.domain.corp/ee/nonexistent-user-component.git"
+    jira {
+        projectKey = 'BUILDSYS'
+    }
+}

--- a/src/test/resources/components-registry/TestComponents.groovy
+++ b/src/test/resources/components-registry/TestComponents.groovy
@@ -2,8 +2,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ee-component" {
     componentDisplayName = "EE Component"
-    componentOwner = "EE Component Owner"
-    releaseManager = "EE Component Release Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "https://github.com/octopusden/octopus-teamcity-automation.git"
     jira {
@@ -13,8 +13,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ie-component" {
     componentDisplayName = "IE Component"
-    componentOwner = "IE Component Owner"
-    releaseManager = "IE Component Release Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ie/ie-component.git"
     jira {
@@ -28,8 +28,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ei-component" {
     componentDisplayName = "EI Component"
-    componentOwner = "EI Component Owner"
-    releaseManager = "EI Component Release Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ei/ei-component.git"
     jira {
@@ -43,8 +43,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ii-component" {
     componentDisplayName = "II Component"
-    componentOwner = "II Component Owner"
-    releaseManager = "II Component Release Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ii/ii-component.git"
     jira {
@@ -58,8 +58,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "maven-component" {
     componentDisplayName = "Maven component"
-    componentOwner = "Maven component Owner"
-    releaseManager = "Maven component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/maven-component.git"
     jira {
@@ -70,8 +70,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "gradle-component" {
     buildSystem = GRADLE
     componentDisplayName = "Gradle component"
-    componentOwner = "Gradle component Owner"
-    releaseManager = "Gradle component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/gradle-component.git"
     jira {
@@ -82,8 +82,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "provided-component" {
     buildSystem = PROVIDED
     componentDisplayName = "Provided component"
-    componentOwner = "Provided component Owner"
-    releaseManager = "Provided component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/provided-component.git"
     jira {
@@ -94,8 +94,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "in-container-component" {
     buildSystem = IN_CONTAINER
     componentDisplayName = "In container component"
-    componentOwner = "In container component Owner"
-    releaseManager = "In container component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/in-container-component.git"
     jira {
@@ -106,8 +106,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "not-supported-component" {
     buildSystem = ESCROW_NOT_SUPPORTED
     componentDisplayName = "Not supported component"
-    componentOwner = "Not supported component Owner"
-    releaseManager = "Not supported component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/not-supported-component.git"
     jira {
@@ -117,8 +117,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "default-jdk-component" {
     componentDisplayName = "Default JDK component"
-    componentOwner = "Default JDK component Owner"
-    releaseManager = "Default JDK component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/default-jdk-component.git"
     jira {
@@ -128,8 +128,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "custom-jdk-component" {
     componentDisplayName = "Custom JDK component"
-    componentOwner = "Custom JDK component Owner"
-    releaseManager = "Custom JDK component Manager"
+    componentOwner = "admin"
+    releaseManager = "admin"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/custom-jdk-component.git"
     jira {

--- a/src/test/resources/components-registry/TestComponents.groovy
+++ b/src/test/resources/components-registry/TestComponents.groovy
@@ -2,8 +2,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ee-component" {
     componentDisplayName = "EE Component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "https://github.com/octopusden/octopus-teamcity-automation.git"
     jira {
@@ -13,8 +13,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ie-component" {
     componentDisplayName = "IE Component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ie/ie-component.git"
     jira {
@@ -28,8 +28,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ei-component" {
     componentDisplayName = "EI Component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ei/ei-component.git"
     jira {
@@ -43,8 +43,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "ii-component" {
     componentDisplayName = "II Component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ii/ii-component.git"
     jira {
@@ -58,8 +58,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "maven-component" {
     componentDisplayName = "Maven component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/maven-component.git"
     jira {
@@ -70,8 +70,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "gradle-component" {
     buildSystem = GRADLE
     componentDisplayName = "Gradle component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/gradle-component.git"
     jira {
@@ -82,8 +82,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "provided-component" {
     buildSystem = PROVIDED
     componentDisplayName = "Provided component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/provided-component.git"
     jira {
@@ -94,8 +94,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "in-container-component" {
     buildSystem = IN_CONTAINER
     componentDisplayName = "In container component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/in-container-component.git"
     jira {
@@ -106,8 +106,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 "not-supported-component" {
     buildSystem = ESCROW_NOT_SUPPORTED
     componentDisplayName = "Not supported component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/not-supported-component.git"
     jira {
@@ -117,8 +117,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "default-jdk-component" {
     componentDisplayName = "Default JDK component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/default-jdk-component.git"
     jira {
@@ -128,8 +128,8 @@ import static org.octopusden.octopus.escrow.BuildSystem.*
 
 "custom-jdk-component" {
     componentDisplayName = "Custom JDK component"
-    componentOwner = "admin"
-    releaseManager = "admin"
+    componentOwner = "testuser"
+    releaseManager = "testuser"
     groupId = "corp.domain"
     vcsUrl = "ssh://git@git.domain.corp/ee/custom-jdk-component.git"
     jira {


### PR DESCRIPTION
…eating the build chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project admin role is automatically assigned to component owners and release managers when a build chain is created.

* **Bug Fixes**
  * Enforced validations to ensure required project and build identifiers are present during build chain and VCS operations.

* **Tests**
  * Added an integration test verifying project-admin role assignment, expanded setup/teardown, and standardized test fixtures to use a dedicated test user.

* **Chores**
  * Updated TeamCity client library to 2.0.84.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->