### PR TITLE
Fix flaky v22 functional tests by raising route timeout and TC2022 CPU

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,7 +126,7 @@ ocTemplate {
                 "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
                 "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
                 "TEAMCITY_ID" to "22",
-                "CPU_REQUEST" to "500m",
+                "CPU_REQUEST" to "1000m",
                 "CPU_LIMIT" to "2500m",
                 "MEM_REQUEST" to "1.5Gi",
                 "MEM_LIMIT" to "3Gi"

--- a/okd/teamcity.yaml
+++ b/okd/teamcity.yaml
@@ -57,7 +57,7 @@ objects:
     metadata:
       name: ${DEPLOYMENT_PREFIX}-teamcity${TEAMCITY_ID}-route
       annotations:
-        haproxy.router.openshift.io/timeout: 120s
+        haproxy.router.openshift.io/timeout: 240s
     spec:
       port:
         targetPort: 8111


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased CPU resources allocated to the TeamCity service to improve performance.
  * Extended connection timeout duration for the TeamCity service to support longer-running operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/octopusden/octopus-teamcity-automation/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->