### PR TITLE
ci: adopt octopusden quality-gates (Phase 4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,16 @@
+# PUBLIC — Gradle compile & UT. Runs on push to main, via workflow_call (merge-gate), and manually.
 name: Gradle Build
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'
+    secrets: inherit

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/teamcity/octopus-teamcity-automation/_VER_/octopus-teamcity-automation-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.3.5
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/teamcity/octopus-teamcity-automation/_VER_/octopus-teamcity-automation-_VER_.jar"

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/teamcity/octopus-teamcity-automation/_VER_/octopus-teamcity-automation-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,30 @@
+# PUBLIC — every PR triggers this workflow and the gate/merge check must be green to merge.
+name: Merge Gate
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+
+  quality:
+    uses: ./.github/workflows/quality.yml
+    secrets: inherit
+
+  security:
+    uses: ./.github/workflows/security.yml
+    secrets: inherit
+
+  gate-merge:
+    name: gate/merge
+    needs: [ build, quality, security ]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.3.5
+        with:
+          needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,15 @@
+# PUBLIC — static quality gates. Runs on push to main, via workflow_call (merge-gate), and manually.
+name: Quality
+
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  quality:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    with:
+      java-version: '21'
+    secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality.coverage.enabled = false), so

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,4 +12,11 @@ jobs:
     uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.3.5
     with:
       java-version: '21'
+      # Coverage is disabled for this repo (octopusQuality.coverage.enabled = false), so
+      # qualityCoverage is a no-op. The default coverage-command still pulls in the `test`
+      # task, whose testcontainers wiring (dockerCompose.isRequiredBy(test)) drives
+      # composeBuild/composeUp -> docker-compose, which is unavailable on the GitHub runner.
+      # Exclude `test` (and the compose lifecycle it triggers) so the gate can run without
+      # Docker/OKD infrastructure.
+      coverage-command: ./gradlew qualityCoverage --no-daemon --stacktrace -x composeBuild -x composeUp -x composeDown -x composeDownForcedOnFailure -x test
     secrets: inherit

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality.coverage.enabled = false), so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.1.8
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.3.5
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.0
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
     with:
       java-version: '21'
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,15 @@
+# PUBLIC — security reports. Runs on push to main, via workflow_call (merge-gate), and manually.
+name: Security
+
+on:
+  push:
+    branches: [ main ]
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  security:
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.3.5
+    with:
+      java-version: '21'
+    secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.avast.gradle.dockercompose.ComposeExtension
-import java.time.Duration
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.time.Duration
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
@@ -13,6 +13,21 @@ plugins {
     signing
     id("org.octopusden.octopus-release-management")
     id("org.octopusden.octopus.oc-template")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("org.octopusden.octopus-quality")
+}
+
+octopusQuality {
+    // Repo has no coverage tool configured — disable coverage verification.
+    coverage {
+        enabled.set(false)
+    }
+    // Enforce Kotlin static analysis (detekt + ktlint); current debt is absorbed by
+    // detekt-baseline.xml / ktlint-baseline.xml so the gate stays green while enforcing.
+    kotlin {
+        failOnViolation.set(true)
+    }
 }
 
 group = "org.octopusden.octopus.automation.teamcity"
@@ -37,7 +52,10 @@ ext {
         set("signingRequired", it.containsKey("ORG_GRADLE_PROJECT_signingKey") && it.containsKey("ORG_GRADLE_PROJECT_signingPassword"))
         set("testPlatform", it.getOrDefault("TEST_PLATFORM", properties["test.platform"]))
         set("dockerRegistry", it.getOrDefault("DOCKER_REGISTRY", properties["docker.registry"]))
-        set("octopusGithubDockerRegistry", it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]))
+        set(
+            "octopusGithubDockerRegistry",
+            it.getOrDefault("OCTOPUS_GITHUB_DOCKER_REGISTRY", project.properties["octopus.github.docker.registry"]),
+        )
         set("okdActiveDeadlineSeconds", it.getOrDefault("OKD_ACTIVE_DEADLINE_SECONDS", properties["okd.active-deadline-seconds"]))
         set("okdProject", it.getOrDefault("OKD_PROJECT", properties["okd.project"]))
         set("okdClusterDomain", it.getOrDefault("OKD_CLUSTER_DOMAIN", properties["okd.cluster-domain"]))
@@ -46,7 +64,9 @@ ext {
 }
 val supportedTestPlatforms = listOf("docker", "okd")
 if (project.ext["testPlatform"] !in supportedTestPlatforms) {
-    throw IllegalArgumentException("Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM")
+    throw IllegalArgumentException(
+        "Test platform must be set to one of the following $supportedTestPlatforms. Start gradle build with -Ptest.platform=... or set env variable TEST_PLATFORM",
+    )
 }
 val mandatoryProperties = mutableListOf("dockerRegistry", "octopusGithubDockerRegistry")
 if (project.ext["testPlatform"] == "okd") {
@@ -58,24 +78,25 @@ val undefinedProperties = mandatoryProperties.filter { (project.ext[it] as Strin
 if (undefinedProperties.isNotEmpty()) {
     throw IllegalArgumentException(
         "Start gradle build with" +
-                (if (undefinedProperties.contains("dockerRegistry")) " -Pdocker.registry=..." else "") +
-                (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " -Poctopus.github.docker.registry=..." else "") +
-                (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " -Pokd.active-deadline-seconds=..." else "") +
-                (if (undefinedProperties.contains("okdProject")) " -Pokd.project=..." else "") +
-                (if (undefinedProperties.contains("okdClusterDomain")) " -Pokd.cluster-domain=..." else "") +
-                " or set env variable(s):" +
-                (if (undefinedProperties.contains("dockerRegistry")) " DOCKER_REGISTRY" else "") +
-                (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " OCTOPUS_GITHUB_DOCKER_REGISTRY" else "") +
-                (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " OKD_ACTIVE_DEADLINE_SECONDS" else "") +
-                (if (undefinedProperties.contains("okdProject")) " OKD_PROJECT" else "") +
-                (if (undefinedProperties.contains("okdClusterDomain")) " OKD_CLUSTER_DOMAIN" else "")
+            (if (undefinedProperties.contains("dockerRegistry")) " -Pdocker.registry=..." else "") +
+            (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " -Poctopus.github.docker.registry=..." else "") +
+            (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " -Pokd.active-deadline-seconds=..." else "") +
+            (if (undefinedProperties.contains("okdProject")) " -Pokd.project=..." else "") +
+            (if (undefinedProperties.contains("okdClusterDomain")) " -Pokd.cluster-domain=..." else "") +
+            " or set env variable(s):" +
+            (if (undefinedProperties.contains("dockerRegistry")) " DOCKER_REGISTRY" else "") +
+            (if (undefinedProperties.contains("octopusGithubDockerRegistry")) " OCTOPUS_GITHUB_DOCKER_REGISTRY" else "") +
+            (if (undefinedProperties.contains("okdActiveDeadlineSeconds")) " OKD_ACTIVE_DEADLINE_SECONDS" else "") +
+            (if (undefinedProperties.contains("okdProject")) " OKD_PROJECT" else "") +
+            (if (undefinedProperties.contains("okdClusterDomain")) " OKD_CLUSTER_DOMAIN" else ""),
     )
 }
+
 fun String.getExt() = project.ext[this].toString()
 
 val commonOkdParameters = mapOf(
     "ACTIVE_DEADLINE_SECONDS" to "okdActiveDeadlineSeconds".getExt(),
-    "DOCKER_REGISTRY" to "dockerRegistry".getExt()
+    "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
 )
 
 ocTemplate {
@@ -84,40 +105,48 @@ ocTemplate {
     namespace.set("okdProject".getExt())
     prefix.set("tc-auto")
 
-    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let{
+    "okdWebConsoleUrl".getExt().takeIf { it.isNotBlank() }?.let {
         webConsoleUrl.set(it)
     }
 
     group("teamcityPVCs").apply {
         service("teamcity22-pvc") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-pvc.yaml"))
-            parameters.set(mapOf(
-                "TEAMCITY_ID" to "22"
-            ))
+            parameters.set(
+                mapOf(
+                    "TEAMCITY_ID" to "22",
+                ),
+            )
         }
         service("teamcity26-pvc") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-pvc.yaml"))
-            parameters.set(mapOf(
-                "TEAMCITY_ID" to "26"
-            ))
+            parameters.set(
+                mapOf(
+                    "TEAMCITY_ID" to "26",
+                ),
+            )
         }
     }
 
     group("teamcitySeedUploaders").apply {
         service("teamcity22-uploader") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "TEAMCITY_ID" to "22"
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                    "TEAMCITY_ID" to "22",
+                ),
+            )
             waitForCompletion.set(true)
         }
         service("teamcity26-uploader") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity-uploader.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "TEAMCITY_ID" to "26"
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                    "TEAMCITY_ID" to "26",
+                ),
+            )
             waitForCompletion.set(true)
         }
     }
@@ -125,47 +154,62 @@ ocTemplate {
     group("teamcityServers").apply {
         service("teamcity22") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
-                "TEAMCITY_ID" to "22",
-                "CPU_REQUEST" to "1000m",
-                "CPU_LIMIT" to "4000m",
-                "MEM_REQUEST" to "1.5Gi",
-                "MEM_LIMIT" to "3Gi"
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                    "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
+                    "TEAMCITY_ID" to "22",
+                    "CPU_REQUEST" to "1000m",
+                    "CPU_LIMIT" to "4000m",
+                    "MEM_REQUEST" to "1.5Gi",
+                    "MEM_LIMIT" to "3Gi",
+                ),
+            )
         }
         service("teamcity26") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/teamcity.yaml"))
-            parameters.set(commonOkdParameters + mapOf(
-                "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
-                "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2026.image-tag"] as String,
-                "TEAMCITY_ID" to "26",
-                "CPU_REQUEST" to "200m",
-                "CPU_LIMIT" to "2500m",
-                "MEM_REQUEST" to "1.5Gi",
-                "MEM_LIMIT" to "3Gi"
-            ))
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
+                    "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2026.image-tag"] as String,
+                    "TEAMCITY_ID" to "26",
+                    "CPU_REQUEST" to "200m",
+                    "CPU_LIMIT" to "2500m",
+                    "MEM_REQUEST" to "1.5Gi",
+                    "MEM_LIMIT" to "3Gi",
+                ),
+            )
         }
     }
 
     group("componentsRegistry").apply {
         service("comp-reg") {
             templateFile.set(rootProject.layout.projectDirectory.file("okd/components-registry.yaml"))
-            val componentsRegistryWorkDir = layout.projectDirectory.dir("src/test/resources/components-registry").asFile.absolutePath
-            parameters.set(commonOkdParameters + mapOf(
-                "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"] as String,
-                "AGGREGATOR_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/Aggregator.groovy").readText(),
-                "DEFAULTS_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/Defaults.groovy").readText(),
-                "TEST_COMPONENTS_GROOVY_CONTENT" to file("${componentsRegistryWorkDir}/TestComponents.groovy").readText(),
-                "APPLICATION_DEV_CONTENT" to layout.projectDirectory.dir("docker/components-registry-service.yaml").asFile.readText()
-            ))
+            val componentsRegistryWorkDir = layout.projectDirectory
+                .dir("src/test/resources/components-registry")
+                .asFile.absolutePath
+            parameters.set(
+                commonOkdParameters + mapOf(
+                    "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"] as String,
+                    "AGGREGATOR_GROOVY_CONTENT" to file("$componentsRegistryWorkDir/Aggregator.groovy").readText(),
+                    "DEFAULTS_GROOVY_CONTENT" to file("$componentsRegistryWorkDir/Defaults.groovy").readText(),
+                    "TEST_COMPONENTS_GROOVY_CONTENT" to file("$componentsRegistryWorkDir/TestComponents.groovy").readText(),
+                    "APPLICATION_DEV_CONTENT" to layout.projectDirectory
+                        .dir("docker/components-registry-service.yaml")
+                        .asFile
+                        .readText(),
+                ),
+            )
         }
     }
 }
 
 configure<ComposeExtension> {
-    useComposeFiles.add(layout.projectDirectory.file("docker/docker-compose.yml").asFile.path)
+    useComposeFiles.add(
+        layout.projectDirectory
+            .file("docker/docker-compose.yml")
+            .asFile.path,
+    )
     waitForTcpPorts.set(true)
     captureContainersOutputToFiles.set(layout.buildDirectory.dir("docker-logs"))
     environment.putAll(
@@ -173,23 +217,39 @@ configure<ComposeExtension> {
             "DOCKER_REGISTRY" to "dockerRegistry".getExt(),
             "TEAMCITY_2022_IMAGE_TAG" to properties["teamcity-2022.image-tag"],
             "TEAMCITY_2026_IMAGE_TAG" to properties["teamcity-2026.image-tag"],
-            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"]
-        )
+            "COMPONENTS_REGISTRY_SERVICE_VERSION" to properties["octopus-components-registry-service.version"],
+        ),
     )
 }
 
 val copyFilesTeamcity2022 = tasks.register<Exec>("copyFilesTeamcity2022") {
     dependsOn("ocCreateTeamcityPVCs", "ocCreateTeamcitySeedUploaders")
-    val localFile = layout.projectDirectory.dir("docker/data.zip").asFile.absolutePath
-    commandLine("oc", "cp", localFile, "-n", "okdProject".getExt(),
-        "${ocTemplate.getPod("teamcity22-uploader")}:/seed/seed.zip")
+    val localFile = layout.projectDirectory
+        .dir("docker/data.zip")
+        .asFile.absolutePath
+    commandLine(
+        "oc",
+        "cp",
+        localFile,
+        "-n",
+        "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity22-uploader")}:/seed/seed.zip",
+    )
 }
 
 val copyFilesTeamcity2026 = tasks.register<Exec>("copyFilesTeamcity2026") {
     dependsOn("ocCreateTeamcityPVCs", "ocCreateTeamcitySeedUploaders")
-    val localFile = layout.projectDirectory.dir("docker/dataV26.zip").asFile.absolutePath
-    commandLine("oc", "cp", localFile, "-n", "okdProject".getExt(),
-        "${ocTemplate.getPod("teamcity26-uploader")}:/seed/seed.zip")
+    val localFile = layout.projectDirectory
+        .dir("docker/dataV26.zip")
+        .asFile.absolutePath
+    commandLine(
+        "oc",
+        "cp",
+        localFile,
+        "-n",
+        "okdProject".getExt(),
+        "${ocTemplate.getPod("teamcity26-uploader")}:/seed/seed.zip",
+    )
 }
 
 val seedTeamcity = tasks.register("seedTeamcity") {
@@ -222,7 +282,7 @@ tasks.withType<Test> {
                 "ocLogsTeamcityServers",
                 "ocLogsComponentsRegistry",
                 "ocDeleteTeamcityPVCs",
-                "ocDeleteComponentsRegistry"
+                "ocDeleteComponentsRegistry",
             )
         }
         "docker" -> {
@@ -260,7 +320,9 @@ dependencies {
     implementation("ch.qos.logback:logback-classic:1.3.14")
     implementation("com.github.ajalt.clikt:clikt:4.4.0")
     implementation("org.octopusden.octopus.octopus-external-systems-clients:teamcity-client:${properties["teamcity-client.version"]}")
-    implementation("org.octopusden.octopus.infrastructure:components-registry-service-client:${properties["octopus-components-registry-service.version"]}")
+    implementation(
+        "org.octopusden.octopus.infrastructure:components-registry-service-client:${properties["octopus-components-registry-service.version"]}",
+    )
     implementation("org.kohsuke:github-api:${properties["github-api.version"]}")
     implementation("com.squareup.okhttp3:okhttp:${properties["okhttp.version"]}")
     with("5.9.2") {
@@ -298,7 +360,10 @@ configurations {
 
 val metarunners = artifacts.add(
     "distributions",
-    layout.buildDirectory.file("distributions/metarunners.zip").get().asFile
+    layout.buildDirectory
+        .file("distributions/metarunners.zip")
+        .get()
+        .asFile,
 ) {
     classifier = "metarunners"
     type = "zip"

--- a/detekt-baseline.xml
+++ b/detekt-baseline.xml
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>LargeClass:ApplicationTest.kt$ApplicationTest</ID>
+    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$"${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=$TEST_BUILD_1,$TEST_BUILD_2;$TEST_SUBPROJECT_1_BUILD_1,$TEST_SUBPROJECT_1_BUILD_2;$TEST_SUBPROJECT_2_BUILD_1,$TEST_SUBPROJECT_2_BUILD_2"</ID>
+    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$"${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=$TEST_BUILD_1;$TEST_SUBPROJECT_1_BUILD_1;$TEST_SUBPROJECT_1_BUILD_1"</ID>
+    <ID>MaxLineLength:ApplicationTest.kt$ApplicationTest$* Tests CreateTeamCityBuildChain for overriding the JDK_VERSION parameter in compile build configurations based on the component's javaVersion.</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$"$NEW_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase."</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$"$OLD_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase."</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$"Attached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${newVcs.id}, vcsRootName=${newVcs.name}, checkoutRules='$checkoutRules'"</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$"Detached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${oldEntry.vcsRoot.id}, vcsRootName=${oldEntry.vcsRoot.name}"</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$"Switched VCS: buildType=${buildType.id}-${buildType.name} -> root=${newVcs.id}-${newVcs.name}, checkoutRules='$checkoutRules' (dryRun = $dryRun)"</ID>
+    <ID>MaxLineLength:TeamcityReplaceVcsRootCommand.kt$TeamcityReplaceVcsRootCommand$val fields = "buildType(id,name,projectId,projectName,webUrl,href,vcs-root-entries(vcs-root-entry(id,vcs-root(id,name,href),checkout-rules)))"</ID>
+    <ID>MaxLineLength:TeamcityUpdateParameterIncrementCommand.kt$TeamcityUpdateParameterIncrementCommand$help = "Configures additional check, optional. If defined, incrementation is performed only if '--current' contains all components of current value of the parameter (for instance, if --current=1.2.7 and parameter value is 1.2, it will be incremented to 1.3)"</ID>
+    <ID>SwallowedException:ApplicationTest.kt$ApplicationTest$e: Exception</ID>
+    <ID>SwallowedException:TeamcityCreateBuildChainCommand.kt$TeamcityCreateBuildChainCommand$e: FeignException.NotFound</ID>
+    <ID>TooGenericExceptionCaught:TeamcityUpdateParameterIncrementCommand.kt$TeamcityUpdateParameterIncrementCommand$e: Exception</ID>
+    <ID>TooGenericExceptionThrown:ApplicationTest.kt$ApplicationTest.Companion$throw Exception("System property 'test.components-registry-host' must be defined")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationTest.kt$ApplicationTest.Companion$throw Exception("System property 'test.teamcity-2022-host' must be defined")</ID>
+    <ID>TooGenericExceptionThrown:ApplicationTest.kt$ApplicationTest.Companion$throw Exception("System property 'test.teamcity-2026-host' must be defined")</ID>
+    <ID>UnusedPrivateMember:ApplicationTest.kt$ApplicationTest.Companion$@JvmStatic private fun invalidCommands(): Stream&lt;Arguments></ID>
+    <ID>UseCheckOrError:ApplicationTest.kt$ApplicationTest$throw IllegalStateException("System property 'jar' must be provided")</ID>
+    <ID>UseRequire:TeamcityUpdateParameterCommand.kt$TeamcityUpdateParameterCommand$throw IllegalArgumentException("Both options --project-ids and --build-type-ids are empty")</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,9 @@ octopus-components-registry-service.version=2.0.59
 octopus-release-management.version=2.0.28
 octopus-oc-template.version=2.0.8
 
+detekt.version=1.23.8
+ktlint-gradle.version=14.0.1
+
 teamcity-2022.image-tag=2022.04.7
 teamcity-2026.image-tag=2026.1
 

--- a/ktlint-baseline.xml
+++ b/ktlint-baseline.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<baseline version="1.0">
+    <file name="src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt">
+        <error line="144" column="141" source="standard:max-line-length" />
+    </file>
+    <file name="src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterIncrementCommand.kt">
+        <error line="18" column="141" source="standard:max-line-length" />
+    </file>
+</baseline>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
         id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
         id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
         id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint-gradle.version"] as String)
-        id("org.octopusden.octopus-quality") version "2.3.5"
+        id("org.octopusden.octopus-quality") version "2.4.0"
     }
     repositories {
         gradlePluginPortal()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,8 +10,15 @@ pluginManagement {
         id("com.gradleup.shadow") version ("8.3.6")
         id("com.avast.gradle.docker-compose") version ("0.16.9")
         id("io.github.gradle-nexus.publish-plugin") version ("1.1.0")
-        id("org.octopusden.octopus-release-management") version(releaseManagementVersion)
+        id("org.octopusden.octopus-release-management") version (releaseManagementVersion)
         id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
+        id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
+        id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint-gradle.version"] as String)
+        id("org.octopusden.octopus-quality") version "2.3.5"
+    }
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
         id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
         id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
         id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint-gradle.version"] as String)
-        id("org.octopusden.octopus-quality") version "2.4.0"
+        id("org.octopusden.octopus-quality") version "2.4.1"
     }
     repositories {
         gradlePluginPortal()

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/Application.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/Application.kt
@@ -5,15 +5,16 @@ import com.github.ajalt.clikt.core.subcommands
 const val SPLIT_SYMBOLS = "[,;]"
 
 fun main(args: Array<String>) {
-    TeamcityCommand().subcommands(
-        TeamcityCreateBuildChainCommand(),
-        TeamcityReplaceVcsRootCommand(),
-        TeamcityUpdateParameterCommand().subcommands(
-            TeamcityUpdateParameterSetCommand(),
-            TeamcityUpdateParameterIncrementCommand()
-        ),
-        TeamcityUploadMetarunnersCommand(),
-        TeamcityGetBuildTypesAgentRequirementsCommand(),
-        TeamcityPostGithubStatusCommand(),
-    ).main(args)
+    TeamcityCommand()
+        .subcommands(
+            TeamcityCreateBuildChainCommand(),
+            TeamcityReplaceVcsRootCommand(),
+            TeamcityUpdateParameterCommand().subcommands(
+                TeamcityUpdateParameterSetCommand(),
+                TeamcityUpdateParameterIncrementCommand(),
+            ),
+            TeamcityUploadMetarunnersCommand(),
+            TeamcityGetBuildTypesAgentRequirementsCommand(),
+            TeamcityPostGithubStatusCommand(),
+        ).main(args)
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/DependencyFailureAction.kt
@@ -1,5 +1,7 @@
 package org.octopusden.octopus.automation.teamcity
 
-enum class DependencyFailureAction(val value: String) {
-    CANCEL("CANCEL")
+enum class DependencyFailureAction(
+    val value: String,
+) {
+    CANCEL("CANCEL"),
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCommand.kt
@@ -12,11 +12,17 @@ import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClassicClie
 import org.slf4j.LoggerFactory
 
 class TeamcityCommand : CliktCommand(name = "") {
-    private val url by option(URL_OPTION, help = "TeamCity URL").convert { it.trim() }.required()
+    private val url by option(URL_OPTION, help = "TeamCity URL")
+        .convert { it.trim() }
+        .required()
         .check("$URL_OPTION is empty") { it.isNotEmpty() }
-    private val user by option(USER_OPTION, help = "TeamCity user").convert { it.trim() }.required()
+    private val user by option(USER_OPTION, help = "TeamCity user")
+        .convert { it.trim() }
+        .required()
         .check("$USER_OPTION is empty") { it.isNotEmpty() }
-    private val password by option(PASSWORD_OPTION, help = "TeamCity password").convert { it.trim() }.required()
+    private val password by option(PASSWORD_OPTION, help = "TeamCity password")
+        .convert { it.trim() }
+        .required()
         .check("$PASSWORD_OPTION is empty") { it.isNotEmpty() }
 
     private val context by findOrSetObject { mutableMapOf<String, Any>() }
@@ -25,6 +31,7 @@ class TeamcityCommand : CliktCommand(name = "") {
         val log = LoggerFactory.getLogger(TeamcityCommand::class.java.`package`.name)
         val client = TeamcityClassicClient(object : ClientParametersProvider {
             override fun getApiUrl() = url
+
             override fun getAuth() = StandardBasicCredCredentialProvider(user, password)
         })
         log.info("TeamCity server version - ${client.getServer().version}")

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -7,22 +7,20 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import feign.FeignException
+import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
+import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClientUrlProvider
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
 import org.octopusden.octopus.components.registry.core.dto.DetailedComponent
 import org.octopusden.octopus.components.registry.core.dto.RepositoryType
-import feign.FeignException
 import org.octopusden.octopus.components.registry.core.exceptions.NotFoundException
-import org.octopusden.octopus.infrastructure.teamcity.client.getProject
-import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
-import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClientUrlProvider
+import org.octopusden.octopus.infrastructure.teamcity.client.ConfigurationType
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityRole
-import org.octopusden.octopus.infrastructure.teamcity.client.ConfigurationType
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityVCSType
-import org.octopusden.octopus.infrastructure.teamcity.client.disableBuildStep
-import org.octopusden.octopus.infrastructure.teamcity.client.getBuildSteps
 import org.octopusden.octopus.infrastructure.teamcity.client.createBuildTypeVcsRootEntry
 import org.octopusden.octopus.infrastructure.teamcity.client.createSnapshotDependency
+import org.octopusden.octopus.infrastructure.teamcity.client.disableBuildStep
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityBuildType
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateBuildType
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateProject
@@ -36,28 +34,39 @@ import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityPropert
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcitySnapshotDependency
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityVcsRoot
+import org.octopusden.octopus.infrastructure.teamcity.client.getBuildSteps
+import org.octopusden.octopus.infrastructure.teamcity.client.getProject
 import org.slf4j.Logger
 
 class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private val context by requireObject<MutableMap<String, Any>>()
 
-    private val parentProjectId by option(PARENT, help = "Teamcity parent project Id").convert { it.trim() }.required()
+    private val parentProjectId by option(PARENT, help = "Teamcity parent project Id")
+        .convert { it.trim() }
+        .required()
         .check("$PARENT is empty") { it.isNotEmpty() }
 
-    private val componentName by option(COMPONENT, help = "Component registry name").convert { it.trim() }.required()
+    private val componentName by option(COMPONENT, help = "Component registry name")
+        .convert { it.trim() }
+        .required()
         .check("$COMPONENT is empty") { it.isNotEmpty() }
 
-    private val minorVersion by option(VERSION, help = "Minor version").convert { it.trim() }.required()
+    private val minorVersion by option(VERSION, help = "Minor version")
+        .convert { it.trim() }
+        .required()
         .check("$VERSION is empty") { it.isNotEmpty() }
 
-    private val componentsRegistryUrl by option(CR, help = "Components Registry service Url").required()
+    private val componentsRegistryUrl by option(CR, help = "Components Registry service Url")
+        .required()
         .check("$CR is empty") { it.isNotEmpty() }
 
     private val createChecklist by option(CREATE_CHECKLIST, help = "Generate check list validation")
-        .convert { it.trim().toBoolean() }.default(true)
+        .convert { it.trim().toBoolean() }
+        .default(true)
 
     private val createRcForce by option(CREATE_RC_FORCE, help = "Force generate RC for non EE components")
-        .convert { it.trim().toBoolean() }.default(false)
+        .convert { it.trim().toBoolean() }
+        .default(false)
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
@@ -67,10 +76,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         val parentProject = client.getProject(parentProjectId)
         val componentsRegistryClient = ClassicComponentsRegistryServiceClient(
             object : ClassicComponentsRegistryServiceClientUrlProvider {
-                override fun getApiUrl(): String {
-                    return componentsRegistryUrl
-                }
-            }
+                override fun getApiUrl(): String = componentsRegistryUrl
+            },
         )
         val detailedComponent = componentsRegistryClient.getDetailedComponent(componentName, minorVersion)
         createBuildChain(parentProject, detailedComponent)
@@ -78,10 +85,10 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
 
     private fun createBuildChain(
         parentProject: TeamcityProject,
-        component: DetailedComponent
+        component: DetailedComponent,
     ) {
         val project = client.createProject(
-            TeamcityCreateProject(name = componentName, parentProject = TeamcityLinkProject(id = parentProject.id))
+            TeamcityCreateProject(name = componentName, parentProject = TeamcityLinkProject(id = parentProject.id)),
         )
         val vcsRootId = createVcsRoot(project.id, component)?.id
         var counter = 0
@@ -94,7 +101,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 else -> throw NotFoundException("Unsupported build system: ${component.buildSystem.name}")
             },
             "[${++counter}.0] Compile & UT [AUTO]",
-            project.id
+            project.id,
         )
         attachVcsRootToBuildType(compileConfig.id, vcsRootId)
         val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
@@ -106,7 +113,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 val rcConfig = createBuildConf(
                     TEMPLATE_RC,
                     "[${++counter}.0] Release Candidate [Manual]",
-                    project.id
+                    project.id,
                 )
                 attachVcsRootToBuildType(rcConfig.id, vcsRootId)
 
@@ -114,21 +121,21 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                     val checklistConfig = createBuildConf(
                         TEMPLATE_CHECKLIST,
                         "[${++counter}.0] Release Checklist Validation [MANUAL]",
-                        project.id
+                        project.id,
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
                     addSnapshotDependency(checklistConfig, rcConfig, DependencyFailureAction.CANCEL)
                     setBuildTypeParameter(
                         checklistConfig.id,
                         "BUILD_VERSION",
-                        "%dep.${compileConfig.id}.BUILD_VERSION%"
+                        "%dep.${compileConfig.id}.BUILD_VERSION%",
                     )
                 }
 
                 val releaseConfig = createBuildConf(
                     TEMPLATE_RELEASE,
                     "[${++counter}.0] Release [Manual]",
-                    project.id
+                    project.id,
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
 
@@ -141,7 +148,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 val releaseConfig = createBuildConf(
                     TEMPLATE_RELEASE,
                     "[${++counter}.0] Release [Manual]",
-                    project.id
+                    project.id,
                 )
                 attachVcsRootToBuildType(releaseConfig.id, vcsRootId)
                 addSnapshotDependency(releaseConfig, compileConfig, DependencyFailureAction.CANCEL)
@@ -152,38 +159,44 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         setBuildTypeParameter(releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
         setProjectParameter(project.id, "COMPONENT_NAME", componentName)
         setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)
-        (listOfNotNull(component.componentOwner) +
-                (component.releaseManager?.split(",") ?: emptyList()))
-            .map { it.trim() }
+        (
+            listOfNotNull(component.componentOwner) +
+                (component.releaseManager?.split(",") ?: emptyList())
+        ).map { it.trim() }
             .filter { it.isNotBlank() }
             .distinct()
             .forEach { assignProjectAdminRoleToUser(project.id, it) }
     }
 
-    private fun attachVcsRootToBuildType(buildTypeId: String, vcsRootId: String?) =
-        vcsRootId?.let {
-            client.createBuildTypeVcsRootEntry(
-                buildTypeId,
-                TeamcityCreateVcsRootEntry(
-                    id = vcsRootId,
-                    vcsRoot = TeamcityLinkVcsRoot(vcsRootId)
-                )
-            )
-        } ?: log.info("Skip attach vcs root to {}", buildTypeId)
-
-    private fun createBuildConf(templateId: String, name: String, projectId: String) =
-        client.createBuildType(
-            TeamcityCreateBuildType(
-                template = TeamcityLinkBuildType(id = templateId),
-                name = name,
-                project = TeamcityLinkProject(id = projectId),
-            )
+    private fun attachVcsRootToBuildType(
+        buildTypeId: String,
+        vcsRootId: String?,
+    ) = vcsRootId?.let {
+        client.createBuildTypeVcsRootEntry(
+            buildTypeId,
+            TeamcityCreateVcsRootEntry(
+                id = vcsRootId,
+                vcsRoot = TeamcityLinkVcsRoot(vcsRootId),
+            ),
         )
+    } ?: log.info("Skip attach vcs root to {}", buildTypeId)
+
+    private fun createBuildConf(
+        templateId: String,
+        name: String,
+        projectId: String,
+    ) = client.createBuildType(
+        TeamcityCreateBuildType(
+            template = TeamcityLinkBuildType(id = templateId),
+            name = name,
+            project = TeamcityLinkProject(id = projectId),
+        ),
+    )
 
     private fun addSnapshotDependency(
         buildType: TeamcityBuildType,
         sourceBuildType: TeamcityBuildType,
-        onDependencyFailure: DependencyFailureAction
+        onDependencyFailure: DependencyFailureAction,
     ) {
         client.createSnapshotDependency(
             buildType.id,
@@ -197,24 +210,33 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                         TeamcityProperty("run-build-on-the-same-agent", "false"),
                         TeamcityProperty("take-started-build-with-same-revisions", "true"),
                         TeamcityProperty("take-successful-builds-only", "true"),
-                    )
+                    ),
                 ),
-                sourceBuildType = TeamcityLinkBuildType(sourceBuildType.id)
-            )
+                sourceBuildType = TeamcityLinkBuildType(sourceBuildType.id),
+            ),
         )
     }
 
-    private fun setBuildTypeParameter(buildTypeId: String, name: String, value: String) =
-        client.setParameter(ConfigurationType.BUILD_TYPE, buildTypeId, name, value).also {
-            log.info("Set parameter $name value $value for build configuration with id $buildTypeId")
-        }
+    private fun setBuildTypeParameter(
+        buildTypeId: String,
+        name: String,
+        value: String,
+    ) = client.setParameter(ConfigurationType.BUILD_TYPE, buildTypeId, name, value).also {
+        log.info("Set parameter $name value $value for build configuration with id $buildTypeId")
+    }
 
-    private fun setProjectParameter(projectId: String, name: String, value: String) =
-        client.setParameter(ConfigurationType.PROJECT, projectId, name, value).also {
-            log.info("Set parameter $name value $value for project with id $projectId")
-        }
+    private fun setProjectParameter(
+        projectId: String,
+        name: String,
+        value: String,
+    ) = client.setParameter(ConfigurationType.PROJECT, projectId, name, value).also {
+        log.info("Set parameter $name value $value for project with id $projectId")
+    }
 
-    private fun assignProjectAdminRoleToUser(projectId: String, username: String) {
+    private fun assignProjectAdminRoleToUser(
+        projectId: String,
+        username: String,
+    ) {
         try {
             client.assignProjectRoleToUser(username, TeamcityRole.PROJECT_ADMIN, projectId)
             log.info("Assigned PROJECT_ADMIN role to user $username for project $projectId")
@@ -223,15 +245,24 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         }
     }
 
-    private fun disableBuildStep(buildTypeId: String, stepNameOrType: String, disable: Boolean = true) {
-        client.getBuildSteps(buildTypeId)
-            .steps.find { step -> step.name == stepNameOrType || step.type == stepNameOrType }
+    private fun disableBuildStep(
+        buildTypeId: String,
+        stepNameOrType: String,
+        disable: Boolean = true,
+    ) {
+        client
+            .getBuildSteps(buildTypeId)
+            .steps
+            .find { step -> step.name == stepNameOrType || step.type == stepNameOrType }
             ?.let { step -> client.disableBuildStep(buildTypeId, step.id, disable) }
             ?: log.warn("Skip disable build step '{}' not found for build type {}", stepNameOrType, buildTypeId)
     }
 
-    private fun createVcsRoot(projectId: String, component: DetailedComponent): TeamcityVcsRoot? {
-        return component.vcsSettings.versionControlSystemRoots.firstOrNull()?.let { vcsRootData ->
+    private fun createVcsRoot(
+        projectId: String,
+        component: DetailedComponent,
+    ): TeamcityVcsRoot? =
+        component.vcsSettings.versionControlSystemRoots.firstOrNull()?.let { vcsRootData ->
             val vcsRootName = "${projectId}_VCS_ROOT"
             when (vcsRootData.type) {
                 RepositoryType.GIT -> client.createVcsRoot(
@@ -248,14 +279,13 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                                 TeamcityProperty("userForTags", "tcagent"),
                                 TeamcityProperty("username", "git"),
                                 TeamcityProperty("ignoreKnownHosts", "true"),
-                            )
-                        )
-                    )
+                            ),
+                        ),
+                    ),
                 )
                 else -> throw NotFoundException("Unsupported vcs type: ${vcsRootData.type}")
             }
         }
-    }
 
     companion object {
         const val COMMAND = "create-build-chain"

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityGetBuildTypesAgentRequirementsCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityGetBuildTypesAgentRequirementsCommand.kt
@@ -6,22 +6,21 @@ import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-import java.io.BufferedWriter
-import java.io.FileWriter
 import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
 import org.octopusden.octopus.infrastructure.teamcity.client.getAgentRequirements
 import org.slf4j.Logger
+import java.io.BufferedWriter
+import java.io.FileWriter
 
 /**
  * Command to get agent requirements for build types in TeamCity.
  */
-class TeamcityGetBuildTypesAgentRequirementsCommand :
-    CliktCommand(name = COMMAND) {
-
+class TeamcityGetBuildTypesAgentRequirementsCommand : CliktCommand(name = COMMAND) {
     private val context by requireObject<MutableMap<String, Any>>()
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
-    private val file by option(FILE, help = "File to save the agent requirements").required()
+    private val file by option(FILE, help = "File to save the agent requirements")
+        .required()
         .check("File must be a valid path") { it.isNotBlank() }
     private val archived by option(ARCHIVED, help = "Include archived projects").flag(default = false)
 
@@ -30,7 +29,7 @@ class TeamcityGetBuildTypesAgentRequirementsCommand :
         val buildTypes =
             client.getBuildTypesWithFields("buildType(id,projectId,projectName,name,href,paused,project(id,name,archived,href,webUrl))")
         BufferedWriter(FileWriter(file)).use { bufferWriter ->
-            //Header
+            // Header
             bufferWriter.write("Project ID;")
             bufferWriter.write("Project Name;")
             bufferWriter.write("Build Type ID;")
@@ -41,12 +40,11 @@ class TeamcityGetBuildTypesAgentRequirementsCommand :
             bufferWriter.write("Disabled;")
             bufferWriter.write("Paused;")
             bufferWriter.write("Archived;\n")
-            //Data
+            // Data
             buildTypes.buildTypes
                 .filter { buildType ->
                     archived || buildType.project?.archived != true
-                }
-                .forEach { buildType ->
+                }.forEach { buildType ->
                     val agentRequirements = client.getAgentRequirements(buildType.id)
                     agentRequirements.agentRequirements.forEach { ar ->
                         bufferWriter.write("${buildType.projectId};")

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityPostGithubStatusCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityPostGithubStatusCommand.kt
@@ -7,12 +7,12 @@ import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
-import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
 import org.kohsuke.github.GHCommitState
 import org.kohsuke.github.GitHubBuilder
 import org.kohsuke.github.extras.okhttp3.OkHttpGitHubConnector
 import org.slf4j.Logger
+import java.util.concurrent.TimeUnit
 
 /**
  * Posts a commit status to GitHub (`POST /repos/{owner}/{repo}/statuses/{sha}`) so TeamCity
@@ -23,34 +23,40 @@ import org.slf4j.Logger
  * not an issue.
  */
 class TeamcityPostGithubStatusCommand : CliktCommand(name = COMMAND) {
-
     private val owner by option(OWNER, help = "GitHub organization / owner")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$OWNER is empty") { it.isNotEmpty() }
 
     private val repo by option(REPO, help = "GitHub repository name")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$REPO is empty") { it.isNotEmpty() }
 
     private val commit by option(COMMIT, help = "Git commit SHA to attach the status to")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$COMMIT is empty") { it.isNotEmpty() }
 
     private val token by option(TOKEN, help = "GitHub API token")
-        .convert { it.trim() }.required()
+        .convert { it.trim() }
+        .required()
         .check("$TOKEN is empty") { it.isNotEmpty() }
 
     private val state by option(STATE, help = "Commit status state: one of $ALLOWED_STATES")
-        .convert { it.trim().lowercase() }.required()
+        .convert { it.trim().lowercase() }
+        .required()
         .check("$STATE must be one of $ALLOWED_STATES") { ALLOWED_STATES.contains(it) }
 
     private val statusContext by option(CONTEXT, help = "Status check context (must match the branch protection rule)")
-        .convert { it.trim() }.default(DEFAULT_CONTEXT)
+        .convert { it.trim() }
+        .default(DEFAULT_CONTEXT)
 
     private val description by option(DESCRIPTION, help = "Short status description").default("")
 
     private val githubApiUrl by option(GITHUB_API_URL, help = "GitHub API base URL")
-        .convert { it.trim().trimEnd('/') }.default(DEFAULT_GITHUB_API_URL)
+        .convert { it.trim().trimEnd('/') }
+        .default(DEFAULT_GITHUB_API_URL)
 
     private val context by requireObject<MutableMap<String, Any>>()
 
@@ -68,13 +74,13 @@ class TeamcityPostGithubStatusCommand : CliktCommand(name = COMMAND) {
             .withOAuthToken(token)
             .withConnector(
                 OkHttpGitHubConnector(
-                    OkHttpClient.Builder()
+                    OkHttpClient
+                        .Builder()
                         .connectTimeout(CONNECT_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
                         .readTimeout(READ_TIMEOUT_MS.toLong(), TimeUnit.MILLISECONDS)
-                        .build()
-                )
-            )
-            .build()
+                        .build(),
+                ),
+            ).build()
         github.getRepository("$owner/$repo").createCommitStatus(
             commit,
             GHCommitState.valueOf(state.uppercase()),

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityReplaceVcsRootCommand.kt
@@ -25,14 +25,23 @@ import java.net.URI
 import java.util.UUID
 
 class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
-
     private val oldVcsRoot by option(OLD_VCS_ROOT, help = "Old Git repository URL")
-        .convert { it.trim() }.required()
-        .check("$OLD_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase.") { it.isValidGitUrl() }
+        .convert { it.trim() }
+        .required()
+        .check(
+            "$OLD_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase.",
+        ) {
+            it.isValidGitUrl()
+        }
 
     private val newVcsRoot by option(NEW_VCS_ROOT, help = "New Git repository URL")
-        .convert { it.trim() }.required()
-        .check("$NEW_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase.") { it.isValidGitUrl() }
+        .convert { it.trim() }
+        .required()
+        .check(
+            "$NEW_VCS_ROOT must be a valid Git URL (e.g. ssh://git@host/org/repo.git or git@host:org/repo.git or https://host/org/repo.git). Use only lowercase.",
+        ) {
+            it.isValidGitUrl()
+        }
 
     private val dryRun by option(DRY_RUN, help = "Dry run only, do not apply")
         .convert { it.toBooleanStrictOrNull() ?: throw IllegalArgumentException("$DRY_RUN must be 'true' or 'false'") }
@@ -50,9 +59,14 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
         updateExplicitGitVcsRoot(oldVcsRoot, newVcsRoot)
     }
 
-    private fun updateExplicitGitVcsRoot(oldVcsRoot: String, newVcsRoot: String) {
+    private fun updateExplicitGitVcsRoot(
+        oldVcsRoot: String,
+        newVcsRoot: String,
+    ) {
         val locator = VcsRootLocator(
-            property = listOf(PropertyLocator(name = PROPERTY_URL, value = oldVcsRoot, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true))
+            property = listOf(
+                PropertyLocator(name = PROPERTY_URL, value = oldVcsRoot, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true),
+            ),
         )
         val roots = client.getVcsRoots(locator).vcsRoots
         if (roots.isNotEmpty()) {
@@ -68,7 +82,10 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
         }
     }
 
-    private fun replaceGenericVcsRoots(oldVcsRoot: String, newVcsRoot: String) {
+    private fun replaceGenericVcsRoots(
+        oldVcsRoot: String,
+        newVcsRoot: String,
+    ) {
         val index = findVcsRootInstancesRootIdsByUrl(oldVcsRoot)
         if (index.rootIds.isEmpty() || index.byBuildType.isEmpty()) {
             log.info("No build configurations referencing $oldVcsRoot found")
@@ -85,74 +102,107 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
             val branch = extractBranchFromBuildType(buildType)
             val newVcs = findOrCreateGitVcsRootInProject(projectId, newVcsRoot, branch)
 
-            val toDetach = client.getBuildTypeVcsRootEntries(buildTypeLocator)
+            val toDetach = client
+                .getBuildTypeVcsRootEntries(buildTypeLocator)
                 .entries
                 .filter { entriesToDetach.contains(it.id) || entriesToDetach.contains(it.vcsRoot.id) }
             val checkoutRules = toDetach.firstOrNull()?.checkoutRules ?: ""
             val createEntry = TeamcityCreateVcsRootEntry(
                 id = newVcs.id,
                 vcsRoot = TeamcityLinkVcsRoot(id = newVcs.id),
-                checkoutRules = checkoutRules
+                checkoutRules = checkoutRules,
             )
             if (!dryRun) {
                 client.createBuildTypeVcsRootEntry(buildTypeLocator, createEntry)
             }
-            log.info("Attached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${newVcs.id}, vcsRootName=${newVcs.name}, checkoutRules='${checkoutRules}'")
+            log.info(
+                "Attached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${newVcs.id}, vcsRootName=${newVcs.name}, checkoutRules='$checkoutRules'",
+            )
             migrateVcsLabeling(buildType.id, toDetach.map { it.vcsRoot.id }.toSet(), newVcs.id)
             toDetach.forEach { oldEntry ->
                 if (!dryRun) {
                     client.deleteBuildTypeVcsRootEntry(buildTypeLocator, oldEntry.id)
                 }
-                log.info("Detached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${oldEntry.vcsRoot.id}, vcsRootName=${oldEntry.vcsRoot.name}")
+                log.info(
+                    "Detached VCS Root: buildTypeId=${buildType.id}, buildTypeName=${buildType.name}, vcsRootId=${oldEntry.vcsRoot.id}, vcsRootName=${oldEntry.vcsRoot.name}",
+                )
             }
-            log.info("Switched VCS: buildType=${buildType.id}-${buildType.name} -> root=${newVcs.id}-${newVcs.name}, checkoutRules='$checkoutRules' (dryRun = $dryRun)")
+            log.info(
+                "Switched VCS: buildType=${buildType.id}-${buildType.name} -> root=${newVcs.id}-${newVcs.name}, checkoutRules='$checkoutRules' (dryRun = $dryRun)",
+            )
         }
     }
 
     private fun findVcsRootInstancesRootIdsByUrl(url: String): InstancesIndex {
-        val propertyLocator = PropertyLocator(name = PROPERTY_URL, value = url, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true)
+        val propertyLocator =
+            PropertyLocator(name = PROPERTY_URL, value = url, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true)
         val allInstances = client.getVcsRootInstances(VcsRootInstanceLocator(property = listOf(propertyLocator))).vcsRootInstances
         val rootIds = allInstances.map { it.vcsRootId }.toSet()
         if (rootIds.isEmpty()) {
             return InstancesIndex(emptySet(), emptyMap())
         }
         val fields = "buildType(id,name,projectId,projectName,webUrl,href,vcs-root-entries(vcs-root-entry(id,vcs-root(id,name,href),checkout-rules)))"
-        val buildTypes = client.getBuildTypesWithVcsRootInstanceLocatorAndFields(VcsRootInstanceLocator(property = listOf(propertyLocator)), fields)
-            .buildTypes
+        val buildTypes = client
+            .getBuildTypesWithVcsRootInstanceLocatorAndFields(
+                VcsRootInstanceLocator(property = listOf(propertyLocator)),
+                fields,
+            ).buildTypes
             .distinctBy { it.id }
-        val byBuild = buildTypes.associateBy(
-            { BuildTypeLocator(id = it.id) },
-            { buildType ->
-                (buildType.vcsRoots?.entries ?: emptyList())
-                    .filter { e -> rootIds.contains(e.vcsRoot.id) || rootIds.contains(e.id) }
-                    .map { it.id }
-                    .toSet()
-            }
-        ).filterValues { it.isNotEmpty() }
+        val byBuild = buildTypes
+            .associateBy(
+                { BuildTypeLocator(id = it.id) },
+                { buildType ->
+                    (buildType.vcsRoots?.entries ?: emptyList())
+                        .filter { e -> rootIds.contains(e.vcsRoot.id) || rootIds.contains(e.id) }
+                        .map { it.id }
+                        .toSet()
+                },
+            ).filterValues { it.isNotEmpty() }
         return InstancesIndex(rootIds, byBuild)
     }
 
     private fun extractBranchFromBuildType(bt: TeamcityBuildType): String {
-        val raw = bt.parameters?.properties?.firstOrNull { it.name == PROPERTY_BUILD_TYPE_BRANCH }?.value?.trim()
+        val raw = bt.parameters
+            ?.properties
+            ?.firstOrNull { it.name == PROPERTY_BUILD_TYPE_BRANCH }
+            ?.value
+            ?.trim()
         if (raw.isNullOrEmpty()) {
             return "refs/heads/master"
         }
         return if (raw.startsWith("refs/")) raw else "refs/heads/$raw"
     }
 
-    private fun findOrCreateGitVcsRootInProject(projectId: String, newVcsUrl: String, branch: String): TeamcityVcsRoot {
-        val candidates = client.getVcsRoots(
-            VcsRootLocator(
-                project = ProjectLocator(id = projectId),
-                property = listOf(
-                    PropertyLocator(name = PROPERTY_URL, value = newVcsUrl, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true),
-                    PropertyLocator(name = PROPERTY_BRANCH, value = branch, matchType = PropertyLocator.MatchType.EQUALS, ignoreCase = true)
-                )
-            )
-        ).vcsRoots
+    private fun findOrCreateGitVcsRootInProject(
+        projectId: String,
+        newVcsUrl: String,
+        branch: String,
+    ): TeamcityVcsRoot {
+        val candidates = client
+            .getVcsRoots(
+                VcsRootLocator(
+                    project = ProjectLocator(id = projectId),
+                    property = listOf(
+                        PropertyLocator(
+                            name = PROPERTY_URL,
+                            value = newVcsUrl,
+                            matchType = PropertyLocator.MatchType.EQUALS,
+                            ignoreCase = true,
+                        ),
+                        PropertyLocator(
+                            name = PROPERTY_BRANCH,
+                            value = branch,
+                            matchType = PropertyLocator.MatchType.EQUALS,
+                            ignoreCase = true,
+                        ),
+                    ),
+                ),
+            ).vcsRoots
         if (candidates.isNotEmpty()) {
             val existing = client.getVcsRoot(VcsRootLocator(id = candidates.first().id))
-            log.info("Found existing VCS Root: projectId=$projectId, vcsRootId=${existing.id}, vcsRootName=${existing.name}, branch=$branch")
+            log.info(
+                "Found existing VCS Root: projectId=$projectId, vcsRootId=${existing.id}, vcsRootName=${existing.name}, branch=$branch",
+            )
             return existing
         }
         val name = generateVcsRootName(newVcsUrl)
@@ -168,7 +218,7 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
                 TeamcityProperty(PROPERTY_IGNORE_KNOWN_HOSTS, TRUE),
                 TeamcityProperty(PROPERTY_AGENT_CLEAN_FILES_POLICY, PROPERTY_VALUE_CLEAN_FILES_POLICY),
                 TeamcityProperty(PROPERTY_AGENT_CLEAN_POLICY, PROPERTY_VALUE_CLEAN_POLICY),
-            )
+            ),
         )
         if (dryRun) {
             val fake = TeamcityVcsRoot(
@@ -176,7 +226,7 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
                 name = "${name}_dryRun",
                 vcsName = VCS_JETBRAINS_GIT,
                 href = "",
-                project = TeamcityProject(id = projectId, name = "Project Name dryRun", href = "", webUrl = "")
+                project = TeamcityProject(id = projectId, name = "Project Name dryRun", href = "", webUrl = ""),
             )
             log.info("Created new VCS Root (dryRun): projectId=$projectId, vcsRootId=${fake.id}, vcsRootName=${fake.name}, branch=$branch")
             return fake
@@ -186,20 +236,26 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
                     name = name,
                     vcsName = VCS_JETBRAINS_GIT,
                     projectLocator = "id:$projectId",
-                    properties = props
-                )
+                    properties = props,
+                ),
             )
             log.info("Created new VCS Root: projectId=$projectId, vcsRootId=${created.id}, vcsRootName=${created.name}, branch=$branch")
             return created
         }
     }
 
-    private fun migrateVcsLabeling(buildTypeId: String, oldRootIds: Set<String>, newRootId: String) {
+    private fun migrateVcsLabeling(
+        buildTypeId: String,
+        oldRootIds: Set<String>,
+        newRootId: String,
+    ) {
         val features = client.getBuildTypeFeatures(BuildTypeLocator(buildTypeId))
         features.features
             .filter { it.type == FEATURE_VCS_LABELING }
             .forEach { feature ->
-                val bound = feature.properties.properties.firstOrNull { it.name == PROPERTY_VCS_ROOT_ID }?.value
+                val bound = feature.properties.properties
+                    .firstOrNull { it.name == PROPERTY_VCS_ROOT_ID }
+                    ?.value
                 if (bound != null && oldRootIds.contains(bound)) {
                     if (!dryRun) {
                         client.updateBuildTypeFeatureParameter(BuildTypeLocator(buildTypeId), feature.id, PROPERTY_VCS_ROOT_ID, newRootId)
@@ -220,8 +276,8 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
         return "${path}_${UUID.randomUUID()}"
     }
 
-    private fun extractPathFromGitUrl(vcsUrl: String): String {
-        return when {
+    private fun extractPathFromGitUrl(vcsUrl: String): String =
+        when {
             vcsUrl.startsWith("ssh://", ignoreCase = true) || vcsUrl.startsWith("https://", ignoreCase = true) -> {
                 URI(vcsUrl).path.removePrefix("/")
             }
@@ -229,7 +285,6 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
                 vcsUrl.substring(vcsUrl.indexOf(':') + 1)
             }
         }
-    }
 
     private fun String.isValidGitUrl(): Boolean {
         if (this != lowercase()) return false
@@ -238,13 +293,13 @@ class TeamcityReplaceVcsRootCommand : CliktCommand(name = COMMAND) {
         val httpsScheme = Regex("""^https://[\w.-]+/[\w./~\-+%]+(\.git)$""")
 
         return baseSshScheme.matches(this) ||
-                githubSshScheme.matches(this) ||
-                httpsScheme.matches(this)
+            githubSshScheme.matches(this) ||
+            httpsScheme.matches(this)
     }
 
     private data class InstancesIndex(
         val rootIds: Set<String>,
-        val byBuildType: Map<BuildTypeLocator, Set<String>>
+        val byBuildType: Map<BuildTypeLocator, Set<String>>,
     )
 
     companion object {

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterCommand.kt
@@ -9,17 +9,29 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 
 class TeamcityUpdateParameterCommand : CliktCommand(name = COMMAND) {
-    private val name by option(NAME_OPTION, help = "TeamCity parameter name").convert { it.trim() }.required()
+    private val name by option(NAME_OPTION, help = "TeamCity parameter name")
+        .convert { it.trim() }
+        .required()
         .check("$NAME_OPTION is empty") { it.isNotEmpty() }
     private val projectIds by option(
-        PROJECT_IDS_OPTION, help = "TeamCity project ids (separated by comma/semicolon), optional"
+        PROJECT_IDS_OPTION,
+        help = "TeamCity project ids (separated by comma/semicolon), optional",
     ).convert { projectIdsValue ->
-        projectIdsValue.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        projectIdsValue
+            .split(SPLIT_SYMBOLS.toRegex())
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
     }.default(emptySet())
     private val buildTypeIds by option(
-        BUILD_TYPE_IDS_OPTION, help = "TeamCity build configuration ids (separated by comma/semicolon), optional"
+        BUILD_TYPE_IDS_OPTION,
+        help = "TeamCity build configuration ids (separated by comma/semicolon), optional",
     ).convert { buildTypeIdsValue ->
-        buildTypeIdsValue.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        buildTypeIdsValue
+            .split(SPLIT_SYMBOLS.toRegex())
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+            .toSet()
     }.default(emptySet())
 
     private val context by requireObject<MutableMap<String, Any>>()
@@ -38,6 +50,10 @@ class TeamcityUpdateParameterCommand : CliktCommand(name = COMMAND) {
         const val BUILD_TYPE_IDS_OPTION = "--build-type-ids"
         const val CONFIG = "config"
 
-        data class UpdateParameterConfig(val name: String, val projectIds: Set<String>, val buildTypeIds: Set<String>)
+        data class UpdateParameterConfig(
+            val name: String,
+            val projectIds: Set<String>,
+            val buildTypeIds: Set<String>,
+        )
     }
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterIncrementCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterIncrementCommand.kt
@@ -15,7 +15,7 @@ class TeamcityUpdateParameterIncrementCommand : CliktCommand(name = COMMAND) {
 
     private val current by option(
         CURRENT_OPTION,
-        help = "Configures additional check, optional. If defined, incrementation is performed only if '--current' contains all components of current value of the parameter (for instance, if --current=1.2.7 and parameter value is 1.2, it will be incremented to 1.3)"
+        help = "Configures additional check, optional. If defined, incrementation is performed only if '--current' contains all components of current value of the parameter (for instance, if --current=1.2.7 and parameter value is 1.2, it will be incremented to 1.3)",
     ).convert { it.trim() }.default("")
 
     override fun run() {
@@ -28,7 +28,11 @@ class TeamcityUpdateParameterIncrementCommand : CliktCommand(name = COMMAND) {
         }
     }
 
-    private fun increment(type: ConfigurationType, id: String, name: String) {
+    private fun increment(
+        type: ConfigurationType,
+        id: String,
+        name: String,
+    ) {
         val componentDelimiters = "[.-]".toRegex()
         val typeName = when (type) {
             ConfigurationType.PROJECT -> "project"

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterSetCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUpdateParameterSetCommand.kt
@@ -12,7 +12,9 @@ import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
 import org.slf4j.Logger
 
 class TeamcityUpdateParameterSetCommand : CliktCommand(name = COMMAND) {
-    private val value by option(VALUE_OPTION, help = "TeamCity parameter value").convert { it.trim() }.required()
+    private val value by option(VALUE_OPTION, help = "TeamCity parameter value")
+        .convert { it.trim() }
+        .required()
         .check("$VALUE_OPTION is empty") { it.isNotEmpty() }
 
     private val context by requireObject<MutableMap<String, Any>>()

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUploadMetarunnersCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityUploadMetarunnersCommand.kt
@@ -6,20 +6,23 @@ import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
+import org.octopusden.octopus.infrastructure.teamcity.client.uploadMetarunner
+import org.slf4j.Logger
 import java.io.ByteArrayOutputStream
 import java.net.URI
 import java.nio.file.Paths
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import kotlin.io.path.name
-import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
-import org.octopusden.octopus.infrastructure.teamcity.client.uploadMetarunner
-import org.slf4j.Logger
 
 class TeamcityUploadMetarunnersCommand : CliktCommand(name = COMMAND) {
-    private val projectId by option(PROJECT_ID_OPTION, help = "TeamCity project id").convert { it.trim() }.required()
+    private val projectId by option(PROJECT_ID_OPTION, help = "TeamCity project id")
+        .convert { it.trim() }
+        .required()
         .check("PROJECT_ID_OPTION is empty") { it.isNotEmpty() }
-    private val zip by option(ZIP_OPTION, help = "URL of a zip file with metarunners").convert { URI(it).toURL() }
+    private val zip by option(ZIP_OPTION, help = "URL of a zip file with metarunners")
+        .convert { URI(it).toURL() }
         .required()
 
     private val context by requireObject<MutableMap<String, Any>>()
@@ -35,13 +38,15 @@ class TeamcityUploadMetarunnersCommand : CliktCommand(name = COMMAND) {
                         val metarunner = Paths.get(it.name).name
                         log.info("Upload metarunner '$metarunner' for project with id $projectId")
                         client.uploadMetarunner(
-                            projectId, metarunner, ByteArrayOutputStream().apply {
-                                zipFile.copyTo(this)
-                            }.toByteArray()
+                            projectId,
+                            metarunner,
+                            ByteArrayOutputStream()
+                                .apply {
+                                    zipFile.copyTo(this)
+                                }.toByteArray(),
                         )
                     }
                 }
-
             }
         }
     }

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -1,14 +1,7 @@
+import com.fasterxml.jackson.databind.ObjectMapper
 import it.skrape.core.htmlDocument
 import it.skrape.matchers.toBe
 import it.skrape.selects.html5.tr
-import java.io.File
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpResponse
-import com.fasterxml.jackson.databind.ObjectMapper
-import java.util.Base64
-import java.util.stream.Stream
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.TestInfo
@@ -33,33 +26,48 @@ import org.octopusden.octopus.infrastructure.teamcity.client.TeamcityClient
 import org.octopusden.octopus.infrastructure.teamcity.client.createBuildStep
 import org.octopusden.octopus.infrastructure.teamcity.client.deleteProject
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityAgentRequirement
-import org.octopusden.octopus.infrastructure.teamcity.client.getBuildSteps
-import org.octopusden.octopus.infrastructure.teamcity.client.getBuildType
-import org.octopusden.octopus.infrastructure.teamcity.client.getBuildTypes
-import org.octopusden.octopus.infrastructure.teamcity.client.getBuildTypeVcsRootEntries
-import org.octopusden.octopus.infrastructure.teamcity.client.getProject
-import org.octopusden.octopus.infrastructure.teamcity.client.getSnapshotDependencies
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateBuildType
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateProject
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateVcsRoot
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityCreateVcsRootEntry
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityLinkProject
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityLinkVcsRoot
-import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityStep
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperties
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityProperty
+import org.octopusden.octopus.infrastructure.teamcity.client.dto.TeamcityStep
 import org.octopusden.octopus.infrastructure.teamcity.client.dto.locator.BuildTypeLocator
-
+import org.octopusden.octopus.infrastructure.teamcity.client.getBuildSteps
+import org.octopusden.octopus.infrastructure.teamcity.client.getBuildType
+import org.octopusden.octopus.infrastructure.teamcity.client.getBuildTypeVcsRootEntries
+import org.octopusden.octopus.infrastructure.teamcity.client.getBuildTypes
+import org.octopusden.octopus.infrastructure.teamcity.client.getProject
+import org.octopusden.octopus.infrastructure.teamcity.client.getSnapshotDependencies
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.Base64
+import java.util.stream.Stream
 
 class ApplicationTest {
     private val jar = System.getProperty("jar") ?: throw IllegalStateException("System property 'jar' must be provided")
     private val javaBin = "${System.getProperty("java.home")}/bin/java"
     private lateinit var testInfo: TestInfo
 
-    private fun execute(name: String, vararg command: String) =
-        ProcessBuilder(javaBin, "-jar", jar, *command).redirectErrorStream(true).redirectOutput(
-            File("").resolve("build").resolve("logs").resolve("$name.log").also { it.parentFile.mkdirs() }).start()
-            .waitFor()
+    private fun execute(
+        name: String,
+        vararg command: String,
+    ) = ProcessBuilder(javaBin, "-jar", jar, *command)
+        .redirectErrorStream(true)
+        .redirectOutput(
+            File("")
+                .resolve("build")
+                .resolve("logs")
+                .resolve("$name.log")
+                .also { it.parentFile.mkdirs() },
+        ).start()
+        .waitFor()
 
     private fun executeForCreateBuildChainCommand(
         config: TeamcityTestConfiguration,
@@ -67,7 +75,7 @@ class ApplicationTest {
         componentName: String,
         minorVersion: String? = "1.0",
         createChecklist: Boolean = true,
-        createRcForce: Boolean = false
+        createRcForce: Boolean = false,
     ): Int =
         execute(
             testMethodName,
@@ -93,7 +101,8 @@ class ApplicationTest {
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_1, parameter, "OLD")
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter, "OLD")
         Assertions.assertEquals(
-            0, execute(
+            0,
+            execute(
                 testInfo.testMethod.get().name,
                 *getTeamcityOptions(config),
                 TeamcityUpdateParameterCommand.COMMAND,
@@ -101,35 +110,44 @@ class ApplicationTest {
                 "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=$TEST_SUBPROJECT_2;$TEST_PROJECT",
                 "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=$TEST_BUILD_1,$TEST_SUBPROJECT_1_BUILD_1",
                 TeamcityUpdateParameterSetCommand.COMMAND,
-                "${TeamcityUpdateParameterSetCommand.VALUE_OPTION}=NEW"
-            )
+                "${TeamcityUpdateParameterSetCommand.VALUE_OPTION}=NEW",
+            ),
         )
         Assertions.assertEquals(
-            "NEW", teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_PROJECT, parameter)
+            "NEW",
+            teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_PROJECT, parameter),
         )
         Assertions.assertEquals(
-            "NEW", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter)
+            "NEW",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "OLD", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter)
+            "OLD",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "OLD", teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_1, parameter)
+            "OLD",
+            teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_1, parameter),
         )
         Assertions.assertEquals(
-            "NEW", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter)
+            "NEW",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "OLD", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter)
+            "OLD",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "NEW", teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_2, parameter)
+            "NEW",
+            teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_2, parameter),
         )
         Assertions.assertEquals(
-            "OLD", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter)
+            "OLD",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "NEW", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter)
+            "NEW",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter),
         )
     }
 
@@ -146,42 +164,51 @@ class ApplicationTest {
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_2, parameter, "INVALID")
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter, "1.3")
         Assertions.assertEquals(
-            0, execute(
+            0,
+            execute(
                 testInfo.testMethod.get().name,
                 *getTeamcityOptions(config),
                 TeamcityUpdateParameterCommand.COMMAND,
                 "${TeamcityUpdateParameterCommand.NAME_OPTION}=$parameter",
                 "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=$TEST_SUBPROJECT_2,$TEST_PROJECT",
                 "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=$TEST_BUILD_1;$TEST_SUBPROJECT_1_BUILD_1;$TEST_SUBPROJECT_1_BUILD_1",
-                TeamcityUpdateParameterIncrementCommand.COMMAND
-            )
+                TeamcityUpdateParameterIncrementCommand.COMMAND,
+            ),
         )
         Assertions.assertThrows(feign.FeignException.NotFound::class.java) {
             teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_PROJECT, parameter)
         }
         Assertions.assertEquals(
-            "1.1", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter)
+            "1.1",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "1.1", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter)
+            "1.1",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "1.2", teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_1, parameter)
+            "1.2",
+            teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_1, parameter),
         )
         Assertions.assertEquals(
-            "1.3", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter)
+            "1.3",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "1.2", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter)
+            "1.2",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "INVALID", teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_2, parameter)
+            "INVALID",
+            teamcityClient.getParameter(ConfigurationType.PROJECT, TEST_SUBPROJECT_2, parameter),
         )
         Assertions.assertEquals(
-            "1.3", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter)
+            "1.3",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "INVALID", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter)
+            "INVALID",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter),
         )
     }
 
@@ -208,7 +235,8 @@ class ApplicationTest {
 
         val projectId = "TestTeamcityAutomation_EeComponent"
         Assertions.assertEquals(
-            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
+            0,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion),
         )
 
         Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
@@ -228,7 +256,7 @@ class ApplicationTest {
             compileConfigId to null,
             rcConfigId to compileConfigId,
             checklistConfigId to rcConfigId,
-            releaseConfigId to rcConfigId
+            releaseConfigId to rcConfigId,
         )
 
         buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
@@ -251,10 +279,19 @@ class ApplicationTest {
 
         val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
         Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"))
-        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"))
-        Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, checklistConfigId, "BUILD_VERSION"),
+        )
+        Assertions.assertEquals(
+            compileBuildVersion,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"),
+        )
 
-        Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+        Assertions.assertEquals(
+            compileConfigId,
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"),
+        )
 
         Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
         Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
@@ -270,7 +307,8 @@ class ApplicationTest {
         val projectId = "TestTeamcityAutomation_EeComponent"
 
         Assertions.assertEquals(
-            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+            0,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName),
         )
 
         listOf(TEST_USER, TEST_USER_2).forEach { username ->
@@ -290,7 +328,8 @@ class ApplicationTest {
         val projectId = "TestTeamcityAutomation_NonexistentUserComponent"
 
         Assertions.assertEquals(
-            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+            0,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName),
         )
     }
 
@@ -305,7 +344,8 @@ class ApplicationTest {
 
         val projectId = "TestTeamcityAutomation_EeComponent"
         Assertions.assertEquals(
-            0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion, false)
+            0,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion, false),
         )
 
         Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
@@ -322,7 +362,7 @@ class ApplicationTest {
         val buildTypesIdAndDependencyId = mapOf(
             compileConfigId to null,
             rcConfigId to compileConfigId,
-            releaseConfigId to rcConfigId
+            releaseConfigId to rcConfigId,
         )
 
         buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
@@ -345,25 +385,25 @@ class ApplicationTest {
         val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
         Assertions.assertEquals(
             compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION")
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, rcConfigId, "BUILD_VERSION"),
         )
         Assertions.assertEquals(
             compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"),
         )
 
         Assertions.assertEquals(
             compileConfigId,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"),
         )
 
         Assertions.assertEquals(
             componentName,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"),
         )
         Assertions.assertEquals(
             minorVersion,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"),
         )
     }
 
@@ -387,12 +427,13 @@ class ApplicationTest {
         val componentNamesToProjectId = mapOf(
             "ie-component" to "TestTeamcityAutomation_IeComponent",
             "ei-component" to "TestTeamcityAutomation_EiComponent",
-            "ii-component" to "TestTeamcityAutomation_IiComponent"
+            "ii-component" to "TestTeamcityAutomation_IiComponent",
         )
 
         componentNamesToProjectId.forEach { (componentName, projectId) ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion)
+                0,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, minorVersion),
             )
 
             Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
@@ -406,7 +447,7 @@ class ApplicationTest {
 
             val buildTypesIdAndDependencyId = mapOf(
                 compileConfigId to null,
-                releaseConfigId to compileConfigId
+                releaseConfigId to compileConfigId,
             )
 
             buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
@@ -426,9 +467,15 @@ class ApplicationTest {
             Assertions.assertTrue(buildSteps.find { it.name == "IncrementTeamCityBuildConfigurationParameter" }?.disabled!!)
 
             val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
-            Assertions.assertEquals(compileBuildVersion, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"))
+            Assertions.assertEquals(
+                compileBuildVersion,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"),
+            )
 
-            Assertions.assertEquals(compileConfigId, teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"))
+            Assertions.assertEquals(
+                compileConfigId,
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"),
+            )
 
             Assertions.assertEquals(componentName, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"))
             Assertions.assertEquals(minorVersion, teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"))
@@ -447,13 +494,14 @@ class ApplicationTest {
 
         Assertions.assertEquals(
             0,
-            executeForCreateBuildChainCommand(config,
+            executeForCreateBuildChainCommand(
+                config,
                 testInfo.methodName(),
                 componentName,
                 minorVersion,
                 createChecklist = false,
-                createRcForce = true
-            )
+                createRcForce = true,
+            ),
         )
 
         Assertions.assertEquals(TEST_PROJECT, teamcityClient.getProject(projectId).parentProjectId)
@@ -470,7 +518,7 @@ class ApplicationTest {
         val buildTypesIdAndDependencyId = mapOf(
             compileConfigId to null,
             rcConfigId to compileConfigId,
-            releaseConfigId to rcConfigId
+            releaseConfigId to rcConfigId,
         )
 
         buildTypesIdAndDependencyId.forEach { (buildTypesId, dependencyId) ->
@@ -493,21 +541,21 @@ class ApplicationTest {
         val compileBuildVersion = "%dep.$compileConfigId.BUILD_VERSION%"
         Assertions.assertEquals(
             compileBuildVersion,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION")
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BUILD_VERSION"),
         )
 
         Assertions.assertEquals(
             compileConfigId,
-            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID")
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, releaseConfigId, "BASE_CONFIGURATION_ID"),
         )
 
         Assertions.assertEquals(
             componentName,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME")
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "COMPONENT_NAME"),
         )
         Assertions.assertEquals(
             minorVersion,
-            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION")
+            teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "PROJECT_VERSION"),
         )
     }
 
@@ -527,17 +575,18 @@ class ApplicationTest {
 
         val componentNamesToProjectId = mapOf(
             defaultJDKComponentName to defaultJDKProjectId,
-            customJDKComponentName to customJDKProjectId
+            customJDKComponentName to customJDKProjectId,
         )
 
         componentNamesToProjectId.forEach { (componentName, projectId) ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+                0,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName),
             )
             val nonCompileConfigIds = listOf(
                 "${projectId}_20ReleaseCandidateManual",
                 "${projectId}_30ReleaseChecklistValidationManual",
-                "${projectId}_40ReleaseManual"
+                "${projectId}_40ReleaseManual",
             )
             nonCompileConfigIds.forEach { configId ->
                 Assertions.assertEquals("1.8", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, configId, "JDK_VERSION"))
@@ -545,10 +594,12 @@ class ApplicationTest {
         }
 
         Assertions.assertEquals(
-            "1.8", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${defaultJDKProjectId}_10CompileUtAuto", "JDK_VERSION")
+            "1.8",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${defaultJDKProjectId}_10CompileUtAuto", "JDK_VERSION"),
         )
         Assertions.assertEquals(
-            "11", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${customJDKProjectId}_10CompileUtAuto", "JDK_VERSION")
+            "11",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${customJDKProjectId}_10CompileUtAuto", "JDK_VERSION"),
         )
     }
 
@@ -565,17 +616,35 @@ class ApplicationTest {
 
         componentNames.forEach { componentName ->
             Assertions.assertEquals(
-                0, executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName)
+                0,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName),
             )
         }
 
-        validateBuildTypeTemplate(teamcityClient, "TestTeamcityAutomation_MavenComponent_10CompileUtAuto", TeamcityCreateBuildChainCommand.TEMPLATE_MAVEN_COMPILE)
-        validateBuildTypeTemplate(teamcityClient, "TestTeamcityAutomation_GradleComponent_10CompileUtAuto", TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE)
-        validateBuildTypeTemplate(teamcityClient, "TestTeamcityAutomation_ProvidedComponent_10CompileUtAuto", TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE)
-        validateBuildTypeTemplate(teamcityClient, "TestTeamcityAutomation_InContainerComponent_10CompileUtAuto", TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE)
+        validateBuildTypeTemplate(
+            teamcityClient,
+            "TestTeamcityAutomation_MavenComponent_10CompileUtAuto",
+            TeamcityCreateBuildChainCommand.TEMPLATE_MAVEN_COMPILE,
+        )
+        validateBuildTypeTemplate(
+            teamcityClient,
+            "TestTeamcityAutomation_GradleComponent_10CompileUtAuto",
+            TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE,
+        )
+        validateBuildTypeTemplate(
+            teamcityClient,
+            "TestTeamcityAutomation_ProvidedComponent_10CompileUtAuto",
+            TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE,
+        )
+        validateBuildTypeTemplate(
+            teamcityClient,
+            "TestTeamcityAutomation_InContainerComponent_10CompileUtAuto",
+            TeamcityCreateBuildChainCommand.TEMPLATE_GRADLE_COMPILE,
+        )
 
         Assertions.assertEquals(
-            1, executeForCreateBuildChainCommand(config, testInfo.methodName(), "not-supported-component")
+            1,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), "not-supported-component"),
         )
     }
 
@@ -593,33 +662,40 @@ class ApplicationTest {
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter, "1.1.2")
         teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter, "1.2.1")
         Assertions.assertEquals(
-            0, execute(
+            0,
+            execute(
                 testInfo.testMethod.get().name,
                 *getTeamcityOptions(config),
                 TeamcityUpdateParameterCommand.COMMAND,
                 "${TeamcityUpdateParameterCommand.NAME_OPTION}=$parameter",
                 "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=$TEST_BUILD_1,$TEST_BUILD_2;$TEST_SUBPROJECT_1_BUILD_1,$TEST_SUBPROJECT_1_BUILD_2;$TEST_SUBPROJECT_2_BUILD_1,$TEST_SUBPROJECT_2_BUILD_2",
                 TeamcityUpdateParameterIncrementCommand.COMMAND,
-                "${TeamcityUpdateParameterIncrementCommand.CURRENT_OPTION}=1.1.1"
-            )
+                "${TeamcityUpdateParameterIncrementCommand.CURRENT_OPTION}=1.1.1",
+            ),
         )
         Assertions.assertEquals(
-            "1.0", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter)
+            "1.0",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "1.0.1", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter)
+            "1.0.1",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "1.2", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter)
+            "1.2",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "1.1.2", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter)
+            "1.1.2",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_2, parameter),
         )
         Assertions.assertEquals(
-            "1.1.2", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter)
+            "1.1.2",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_1, parameter),
         )
         Assertions.assertEquals(
-            "1.2.1", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter)
+            "1.2.1",
+            teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_2_BUILD_2, parameter),
         )
     }
 
@@ -631,13 +707,14 @@ class ApplicationTest {
 
         val metarunners = ApplicationTest::class.java.getResource("metarunners.zip")!!
         Assertions.assertEquals(
-            0, execute(
+            0,
+            execute(
                 testInfo.testMethod.get().name,
                 *getTeamcityOptions(config),
                 TeamcityUploadMetarunnersCommand.COMMAND,
                 "${TeamcityUploadMetarunnersCommand.PROJECT_ID_OPTION}=$TEST_PROJECT",
-                "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=$metarunners"
-            )
+                "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=$metarunners",
+            ),
         )
 
         validateUploadedMetarunners(config, teamcityClient)
@@ -648,12 +725,13 @@ class ApplicationTest {
     fun testGetBuildTypesAgentRequirements(config: TeamcityTestConfiguration) {
         val file = File("build").resolve("logs").resolve("${testInfo.testMethod.get().name}.csv")
         Assertions.assertEquals(
-            0, execute(
+            0,
+            execute(
                 testInfo.testMethod.get().name,
                 *getTeamcityOptions(config),
                 TeamcityGetBuildTypesAgentRequirementsCommand.COMMAND,
-                "${TeamcityGetBuildTypesAgentRequirementsCommand.FILE}=$file"
-            )
+                "${TeamcityGetBuildTypesAgentRequirementsCommand.FILE}=$file",
+            ),
         )
         Assertions.assertTrue(file.exists())
         Assertions.assertTrue(file.readText().contains("teamcity.agent.jvm.os.name;Mac OS X"))
@@ -677,27 +755,53 @@ class ApplicationTest {
                     listOf(
                         TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_URL, oldUrl),
                         TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_BRANCH, "refs/heads/master"),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_BRANCH_SPEC, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_BRANCH_SPEC),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_USERNAME, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_USERNAME),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_AUTH_METHOD, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_AUTH_METHOD),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_USERNAME_STYLE, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_USERNAME_STYLE),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_SUBMODULE_CHECKOUT, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_SUBMODULE_CHECKOUT),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_BRANCH_SPEC,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_BRANCH_SPEC,
+                        ),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_USERNAME,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_USERNAME,
+                        ),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_AUTH_METHOD,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_AUTH_METHOD,
+                        ),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_USERNAME_STYLE,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_USERNAME_STYLE,
+                        ),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_SUBMODULE_CHECKOUT,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_SUBMODULE_CHECKOUT,
+                        ),
                         TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_IGNORE_KNOWN_HOSTS, TeamcityReplaceVcsRootCommand.TRUE),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_AGENT_CLEAN_FILES_POLICY, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_CLEAN_FILES_POLICY),
-                        TeamcityProperty(TeamcityReplaceVcsRootCommand.PROPERTY_AGENT_CLEAN_POLICY, TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_CLEAN_POLICY)
-                    )
-                )
-            )
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_AGENT_CLEAN_FILES_POLICY,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_CLEAN_FILES_POLICY,
+                        ),
+                        TeamcityProperty(
+                            TeamcityReplaceVcsRootCommand.PROPERTY_AGENT_CLEAN_POLICY,
+                            TeamcityReplaceVcsRootCommand.PROPERTY_VALUE_CLEAN_POLICY,
+                        ),
+                    ),
+                ),
+            ),
         )
         teamcityClient.createBuildTypeVcsRootEntry(
             buildType = BuildTypeLocator(TEST_SUBPROJECT_1_BUILD_1),
             vcsRootEntry = TeamcityCreateVcsRootEntry(
                 id = created.id,
                 vcsRoot = TeamcityLinkVcsRoot(id = created.id),
-                checkoutRules = ""
-            )
+                checkoutRules = "",
+            ),
         )
-        teamcityClient.setParameter(ConfigurationType.BUILD_TYPE, TEST_SUBPROJECT_1_BUILD_1, TeamcityReplaceVcsRootCommand.PROPERTY_BUILD_TYPE_BRANCH, "master")
+        teamcityClient.setParameter(
+            ConfigurationType.BUILD_TYPE,
+            TEST_SUBPROJECT_1_BUILD_1,
+            TeamcityReplaceVcsRootCommand.PROPERTY_BUILD_TYPE_BRANCH,
+            "master",
+        )
 
         val exitCode = execute(
             testInfo.testMethod.get().name,
@@ -705,7 +809,7 @@ class ApplicationTest {
             TeamcityReplaceVcsRootCommand.COMMAND,
             "${TeamcityReplaceVcsRootCommand.OLD_VCS_ROOT}=$oldUrl",
             "${TeamcityReplaceVcsRootCommand.NEW_VCS_ROOT}=$newUrl",
-            "${TeamcityReplaceVcsRootCommand.DRY_RUN}=false"
+            "${TeamcityReplaceVcsRootCommand.DRY_RUN}=false",
         )
         Assertions.assertEquals(0, exitCode)
         val actualUrl = teamcityClient.getVcsRootProperty(created.id, TeamcityReplaceVcsRootCommand.PROPERTY_URL)
@@ -718,83 +822,116 @@ class ApplicationTest {
 
     @ParameterizedTest
     @MethodSource("validCommands")
-    fun testValidCommands(name: String, command: Array<String>) = Assertions.assertEquals(0, execute(name, *command))
+    fun testValidCommands(
+        name: String,
+        command: Array<String>,
+    ) = Assertions.assertEquals(0, execute(name, *command))
 
     @ParameterizedTest
     @MethodSource("invalidCommands")
-    fun testInvalidCommands(name: String, command: Array<String>) = Assertions.assertEquals(1, execute(name, *command))
+    fun testInvalidCommands(
+        name: String,
+        command: Array<String>,
+    ) = Assertions.assertEquals(1, execute(name, *command))
 
     @BeforeEach
     fun init(testInfo: TestInfo) {
         this.testInfo = testInfo
     }
 
-    private fun cleanUpResources(teamcityClient: TeamcityClassicClient, config: TeamcityTestConfiguration) {
+    private fun cleanUpResources(
+        teamcityClient: TeamcityClassicClient,
+        config: TeamcityTestConfiguration,
+    ) {
         try {
             teamcityClient.deleteProject(TEST_PROJECT)
         } catch (e: Exception) {
-            //do nothing
+            // do nothing
         }
         createTestUser(config.host, TEST_USER)
         createTestUser(config.host, TEST_USER_2)
         teamcityClient.createProject(
             TeamcityCreateProject(
-                TEST_PROJECT, TEST_PROJECT, TeamcityLinkProject("RDDepartment")
-            )
+                TEST_PROJECT,
+                TEST_PROJECT,
+                TeamcityLinkProject("RDDepartment"),
+            ),
         )
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "JDK_VERSION", "1.8")
         teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_BUILD_1, TEST_BUILD_1, project = TeamcityLinkProject(TEST_PROJECT)
-            )
+                TEST_BUILD_1,
+                TEST_BUILD_1,
+                project = TeamcityLinkProject(TEST_PROJECT),
+            ),
         )
         teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_BUILD_2, TEST_BUILD_2, project = TeamcityLinkProject(TEST_PROJECT)
-            )
+                TEST_BUILD_2,
+                TEST_BUILD_2,
+                project = TeamcityLinkProject(TEST_PROJECT),
+            ),
         )
         teamcityClient.createProject(
             TeamcityCreateProject(
-                TEST_SUBPROJECT_1, TEST_SUBPROJECT_1, TeamcityLinkProject(TEST_PROJECT)
-            )
+                TEST_SUBPROJECT_1,
+                TEST_SUBPROJECT_1,
+                TeamcityLinkProject(TEST_PROJECT),
+            ),
         )
         teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_SUBPROJECT_1_BUILD_1, TEST_SUBPROJECT_1_BUILD_1, project = TeamcityLinkProject(TEST_SUBPROJECT_1)
-            )
+                TEST_SUBPROJECT_1_BUILD_1,
+                TEST_SUBPROJECT_1_BUILD_1,
+                project = TeamcityLinkProject(TEST_SUBPROJECT_1),
+            ),
         )
         teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_SUBPROJECT_1_BUILD_2, TEST_SUBPROJECT_1_BUILD_2, project = TeamcityLinkProject(TEST_SUBPROJECT_1)
-            )
+                TEST_SUBPROJECT_1_BUILD_2,
+                TEST_SUBPROJECT_1_BUILD_2,
+                project = TeamcityLinkProject(TEST_SUBPROJECT_1),
+            ),
         )
         teamcityClient.createProject(
             TeamcityCreateProject(
-                TEST_SUBPROJECT_2, TEST_SUBPROJECT_2, TeamcityLinkProject(TEST_PROJECT)
-            )
+                TEST_SUBPROJECT_2,
+                TEST_SUBPROJECT_2,
+                TeamcityLinkProject(TEST_PROJECT),
+            ),
         )
         teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_SUBPROJECT_2_BUILD_1, TEST_SUBPROJECT_2_BUILD_1, project = TeamcityLinkProject(TEST_SUBPROJECT_2)
-            )
+                TEST_SUBPROJECT_2_BUILD_1,
+                TEST_SUBPROJECT_2_BUILD_1,
+                project = TeamcityLinkProject(TEST_SUBPROJECT_2),
+            ),
         )
         val buildType = teamcityClient.createBuildType(
             TeamcityCreateBuildType(
-                TEST_SUBPROJECT_2_BUILD_2, TEST_SUBPROJECT_2_BUILD_2, project = TeamcityLinkProject(TEST_SUBPROJECT_2)
-            )
+                TEST_SUBPROJECT_2_BUILD_2,
+                TEST_SUBPROJECT_2_BUILD_2,
+                project = TeamcityLinkProject(TEST_SUBPROJECT_2),
+            ),
         )
         val properties = TeamcityProperties(
             listOf(
                 TeamcityProperty("property-value", "Mac OS X"),
                 TeamcityProperty("property-name", "teamcity.agent.jvm.os.name"),
-            )
+            ),
         )
 
         teamcityClient.addAgentRequirementToBuildType(
             BuildTypeLocator(buildType.id),
-            TeamcityAgentRequirement(null, "agentName", "equals", null, null, null,
-                properties
-                )
+            TeamcityAgentRequirement(
+                null,
+                "agentName",
+                "equals",
+                null,
+                null,
+                null,
+                properties,
+            ),
         )
 
         val templates = listOf(
@@ -807,10 +944,11 @@ class ApplicationTest {
         templates.forEach {
             teamcityClient.createBuildType(
                 TeamcityCreateBuildType(
-                    it, it,
+                    it,
+                    it,
                     project = TeamcityLinkProject(TEST_PROJECT),
-                    templateFlag = true
-                )
+                    templateFlag = true,
+                ),
             )
         }
 
@@ -819,10 +957,12 @@ class ApplicationTest {
             teamcityClient.createBuildStep(
                 TeamcityCreateBuildChainCommand.TEMPLATE_RELEASE,
                 step = TeamcityStep(
-                    stepName, stepName, stepName,
+                    stepName,
+                    stepName,
+                    stepName,
                     disabled = false,
-                    properties = TeamcityProperties(listOf(TeamcityProperty("property", "")))
-                )
+                    properties = TeamcityProperties(listOf(TeamcityProperty("property", ""))),
+                ),
             )
         }
     }
@@ -830,97 +970,117 @@ class ApplicationTest {
     private fun validateSnapshotDependencyFailureAction(
         teamcityClient: TeamcityClassicClient,
         buildTypeId: String,
-        expectedAction: DependencyFailureAction
+        expectedAction: DependencyFailureAction,
     ) {
         val snapshotDependencies = teamcityClient.getSnapshotDependencies(buildTypeId).snapshotDependencies
         Assertions.assertEquals(1, snapshotDependencies.size)
         val properties = snapshotDependencies[0].properties.properties.associate { it.name to it.value }
         Assertions.assertEquals(
-            expectedAction.value, properties["run-build-if-dependency-failed"],
-            "run-build-if-dependency-failed for $buildTypeId"
+            expectedAction.value,
+            properties["run-build-if-dependency-failed"],
+            "run-build-if-dependency-failed for $buildTypeId",
         )
         Assertions.assertEquals(
-            expectedAction.value, properties["run-build-if-dependency-failed-to-start"],
-            "run-build-if-dependency-failed-to-start for $buildTypeId"
+            expectedAction.value,
+            properties["run-build-if-dependency-failed-to-start"],
+            "run-build-if-dependency-failed-to-start for $buildTypeId",
         )
     }
 
-    private fun createTestUser(host: String, username: String) {
+    private fun createTestUser(
+        host: String,
+        username: String,
+    ) {
         val response = HttpClient.newHttpClient().send(
-            HttpRequest.newBuilder()
+            HttpRequest
+                .newBuilder()
                 .uri(URI("$host/app/rest/users"))
                 .header("Content-Type", "application/json")
                 .header("Accept", "application/json")
                 .header(
                     "Authorization",
-                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}"
-                )
-                .POST(HttpRequest.BodyPublishers.ofString("""{"username":"$username","password":"$username"}"""))
+                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}",
+                ).POST(HttpRequest.BodyPublishers.ofString("""{"username":"$username","password":"$username"}"""))
                 .build(),
-            HttpResponse.BodyHandlers.ofString()
+            HttpResponse.BodyHandlers.ofString(),
         )
         val status = response.statusCode()
         Assertions.assertTrue(
             status in 200..299 || status == 400,
-            "Failed to create user '$username': HTTP $status - ${response.body()}"
+            "Failed to create user '$username': HTTP $status - ${response.body()}",
         )
     }
 
-    private data class RoleEntry(val roleId: String, val scope: String)
+    private data class RoleEntry(
+        val roleId: String,
+        val scope: String,
+    )
 
-    private fun getUserRoles(host: String, username: String): List<RoleEntry> {
+    private fun getUserRoles(
+        host: String,
+        username: String,
+    ): List<RoleEntry> {
         val response = HttpClient.newHttpClient().send(
-            HttpRequest.newBuilder()
+            HttpRequest
+                .newBuilder()
                 .uri(URI("$host/app/rest/users/username:$username/roles"))
                 .header("Accept", "application/json")
                 .header(
                     "Authorization",
-                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}"
-                )
-                .GET()
+                    "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}",
+                ).GET()
                 .build(),
-            HttpResponse.BodyHandlers.ofString()
+            HttpResponse.BodyHandlers.ofString(),
         )
         Assertions.assertEquals(200, response.statusCode(), "Failed to get roles for user '$username'")
         val tree = ObjectMapper().readTree(response.body())
         return tree["role"]?.map { node ->
             RoleEntry(
                 roleId = node["roleId"].asText(),
-                scope = node["scope"].asText()
+                scope = node["scope"].asText(),
             )
         } ?: emptyList()
     }
 
-    private fun validateBuildTypeTemplate(teamcityClient: TeamcityClassicClient, buildTypeId: String, templateId: String) {
+    private fun validateBuildTypeTemplate(
+        teamcityClient: TeamcityClassicClient,
+        buildTypeId: String,
+        templateId: String,
+    ) {
         val templateBuildType = teamcityClient.getBuildType(buildTypeId).templates?.buildTypes
         Assertions.assertEquals(1, templateBuildType?.size)
         Assertions.assertEquals(templateId, templateBuildType?.get(0)?.id)
     }
 
-    private fun validateUploadedMetarunners(config: TeamcityTestConfiguration, client: TeamcityClient) {
+    private fun validateUploadedMetarunners(
+        config: TeamcityTestConfiguration,
+        client: TeamcityClient,
+    ) {
         val expected = listOf("TestMetarunner", "TestMetarunner2", "TestMetarunner3")
         if (config.version >= 2026) {
             expected.forEach { recipeId ->
                 Assertions.assertNotNull(
                     client.getRecipeOverviewV2026(recipeId, TEST_PROJECT),
-                    "Recipe '$recipeId' not found in project $TEST_PROJECT"
+                    "Recipe '$recipeId' not found in project $TEST_PROJECT",
                 )
             }
         } else {
             val tabName = if (config.version < 2025) "metaRunner" else "recipe"
             val url = "${config.host}/admin/editProject.html?projectId=$TEST_PROJECT&tab=$tabName"
             htmlDocument(
-                HttpClient.newHttpClient().send(
-                    HttpRequest.newBuilder()
-                        .uri(URI(url))
-                        .header(
-                            "Authorization",
-                            "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}"
-                        )
-                        .GET()
-                        .build(),
-                    HttpResponse.BodyHandlers.ofString()
-                ).body()
+                HttpClient
+                    .newHttpClient()
+                    .send(
+                        HttpRequest
+                            .newBuilder()
+                            .uri(URI(url))
+                            .header(
+                                "Authorization",
+                                "Basic ${Base64.getEncoder().encodeToString("$TEAMCITY_USER:$TEAMCITY_PASSWORD".toByteArray())}",
+                            ).GET()
+                            .build(),
+                        HttpResponse.BodyHandlers.ofString(),
+                    ).body(),
             ) {
                 expected.forEach { id ->
                     tr {
@@ -957,156 +1117,158 @@ class ApplicationTest {
         private val hostComponentsRegistry = System.getProperty("test.components-registry-host")
             ?: throw Exception("System property 'test.components-registry-host' must be defined")
 
-        private fun createClient(config: TeamcityTestConfiguration): TeamcityClassicClient {
-            return TeamcityClassicClient(object : ClientParametersProvider {
+        private fun createClient(config: TeamcityTestConfiguration): TeamcityClassicClient =
+            TeamcityClassicClient(object : ClientParametersProvider {
                 override fun getApiUrl() = config.host
+
                 override fun getAuth() = StandardBasicCredCredentialProvider(TEAMCITY_USER, TEAMCITY_PASSWORD)
             })
-        }
 
-        private fun getTeamcityOptions(config: TeamcityTestConfiguration) = arrayOf(
-            "${TeamcityCommand.URL_OPTION}=${config.host}",
-            "${TeamcityCommand.USER_OPTION}=$TEAMCITY_USER",
-            "${TeamcityCommand.PASSWORD_OPTION}=$TEAMCITY_PASSWORD"
-        )
+        private fun getTeamcityOptions(config: TeamcityTestConfiguration) =
+            arrayOf(
+                "${TeamcityCommand.URL_OPTION}=${config.host}",
+                "${TeamcityCommand.USER_OPTION}=$TEAMCITY_USER",
+                "${TeamcityCommand.PASSWORD_OPTION}=$TEAMCITY_PASSWORD",
+            )
 
         @JvmStatic
-        fun teamcityConfigurations(): List<TeamcityTestConfiguration> = listOf(
-            TeamcityTestConfiguration(
-                name = "v22",
-                host = "http://$hostTeamcity2022",
-                version = 2022
-            ),
-            TeamcityTestConfiguration(
-                name = "v26",
-                host = "http://$hostTeamcity2026",
-                version = 2026
+        fun teamcityConfigurations(): List<TeamcityTestConfiguration> =
+            listOf(
+                TeamcityTestConfiguration(
+                    name = "v22",
+                    host = "http://$hostTeamcity2022",
+                    version = 2022,
+                ),
+                TeamcityTestConfiguration(
+                    name = "v26",
+                    host = "http://$hostTeamcity2026",
+                    version = 2026,
+                ),
             )
-        )
 
         @JvmStatic
         fun teamcityContexts(): List<TeamcityTestConfiguration> =
             teamcityConfigurations().map { TeamcityTestConfiguration(it.name, it.host, it.version) }
 
-        //<editor-fold defaultstate="collapsed" desc="Test Data">
+        // <editor-fold defaultstate="collapsed" desc="Test Data">
         @JvmStatic
-        fun validCommands(): Stream<Arguments> {
-            return teamcityConfigurations().flatMap { config ->
-                listOf(
-                    "validCommand" to arrayOf(HELP_OPTION),
-                    "validCommand2" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "validCommand3" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
-                        "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=test",
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "validCommand4" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
-                        "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=test",
-                        "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=",
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "validCommand5" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUploadMetarunnersCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "validCommand6" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityPostGithubStatusCommand.COMMAND,
-                        HELP_OPTION
-                    )
-                ).map { (name, args) -> Arguments.of(name, args) }
-            }.stream()
-        }
+        fun validCommands(): Stream<Arguments> =
+            teamcityConfigurations()
+                .flatMap { config ->
+                    listOf(
+                        "validCommand" to arrayOf(HELP_OPTION),
+                        "validCommand2" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "validCommand3" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
+                            "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=test",
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "validCommand4" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
+                            "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=test",
+                            "${TeamcityUpdateParameterCommand.BUILD_TYPE_IDS_OPTION}=",
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "validCommand5" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUploadMetarunnersCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "validCommand6" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityPostGithubStatusCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                    ).map { (name, args) -> Arguments.of(name, args) }
+                }.stream()
 
         @JvmStatic
-        private fun invalidCommands(): Stream<Arguments> {
-            return teamcityConfigurations().flatMap { config ->
-                listOf(
-                    "invalidCommand" to arrayOf(TeamcityUpdateParameterCommand.COMMAND, HELP_OPTION),
-                    "invalidCommand2" to arrayOf(
-                        *(getTeamcityOptions(config).clone().also { it[2] = "${TeamcityCommand.PASSWORD_OPTION}=" }),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand3" to arrayOf(
-                        *(getTeamcityOptions(config).clone().also { it[2] = "${TeamcityCommand.PASSWORD_OPTION}=invalid" }),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand4" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
-                        "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}= , ",
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand5" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        "${TeamcityUpdateParameterCommand.NAME_OPTION}= ",
-                        "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=test",
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand6" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand7" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUpdateParameterCommand.COMMAND,
-                        TeamcityUpdateParameterSetCommand.COMMAND,
-                        HELP_OPTION
-                    ),
-                    "invalidCommand8" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUploadMetarunnersCommand.COMMAND,
-                        "${TeamcityUploadMetarunnersCommand.PROJECT_ID_OPTION}= ",
-                        "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=file:///test.zip"
-                    ),
-                    "invalidCommand9" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityUploadMetarunnersCommand.COMMAND,
-                        "${TeamcityUploadMetarunnersCommand.PROJECT_ID_OPTION}=test",
-                        "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=invalid"
-                    ),
-                    "invalidCommand10" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityPostGithubStatusCommand.COMMAND,
-                        "${TeamcityPostGithubStatusCommand.OWNER}=owner",
-                        "${TeamcityPostGithubStatusCommand.REPO}=repo",
-                        "${TeamcityPostGithubStatusCommand.COMMIT}=0000000000000000000000000000000000000000",
-                        "${TeamcityPostGithubStatusCommand.TOKEN}=token",
-                        "${TeamcityPostGithubStatusCommand.STATE}=invalid"
-                    ),
-                    "invalidCommand11" to arrayOf(
-                        *getTeamcityOptions(config),
-                        TeamcityPostGithubStatusCommand.COMMAND,
-                        "${TeamcityPostGithubStatusCommand.OWNER}= ",
-                        "${TeamcityPostGithubStatusCommand.REPO}=repo",
-                        "${TeamcityPostGithubStatusCommand.COMMIT}=0000000000000000000000000000000000000000",
-                        "${TeamcityPostGithubStatusCommand.TOKEN}=token",
-                        "${TeamcityPostGithubStatusCommand.STATE}=success"
-                    )
-                ).map { (name, args) -> Arguments.of(name, args) }
-            }.stream()
-        }
-        //</editor-fold>
+        private fun invalidCommands(): Stream<Arguments> =
+            teamcityConfigurations()
+                .flatMap { config ->
+                    listOf(
+                        "invalidCommand" to arrayOf(TeamcityUpdateParameterCommand.COMMAND, HELP_OPTION),
+                        "invalidCommand2" to arrayOf(
+                            *(getTeamcityOptions(config).clone().also { it[2] = "${TeamcityCommand.PASSWORD_OPTION}=" }),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand3" to arrayOf(
+                            *(getTeamcityOptions(config).clone().also { it[2] = "${TeamcityCommand.PASSWORD_OPTION}=invalid" }),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand4" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
+                            "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}= , ",
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand5" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            "${TeamcityUpdateParameterCommand.NAME_OPTION}= ",
+                            "${TeamcityUpdateParameterCommand.PROJECT_IDS_OPTION}=test",
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand6" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            "${TeamcityUpdateParameterCommand.NAME_OPTION}=test",
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand7" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUpdateParameterCommand.COMMAND,
+                            TeamcityUpdateParameterSetCommand.COMMAND,
+                            HELP_OPTION,
+                        ),
+                        "invalidCommand8" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUploadMetarunnersCommand.COMMAND,
+                            "${TeamcityUploadMetarunnersCommand.PROJECT_ID_OPTION}= ",
+                            "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=file:///test.zip",
+                        ),
+                        "invalidCommand9" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityUploadMetarunnersCommand.COMMAND,
+                            "${TeamcityUploadMetarunnersCommand.PROJECT_ID_OPTION}=test",
+                            "${TeamcityUploadMetarunnersCommand.ZIP_OPTION}=invalid",
+                        ),
+                        "invalidCommand10" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityPostGithubStatusCommand.COMMAND,
+                            "${TeamcityPostGithubStatusCommand.OWNER}=owner",
+                            "${TeamcityPostGithubStatusCommand.REPO}=repo",
+                            "${TeamcityPostGithubStatusCommand.COMMIT}=0000000000000000000000000000000000000000",
+                            "${TeamcityPostGithubStatusCommand.TOKEN}=token",
+                            "${TeamcityPostGithubStatusCommand.STATE}=invalid",
+                        ),
+                        "invalidCommand11" to arrayOf(
+                            *getTeamcityOptions(config),
+                            TeamcityPostGithubStatusCommand.COMMAND,
+                            "${TeamcityPostGithubStatusCommand.OWNER}= ",
+                            "${TeamcityPostGithubStatusCommand.REPO}=repo",
+                            "${TeamcityPostGithubStatusCommand.COMMIT}=0000000000000000000000000000000000000000",
+                            "${TeamcityPostGithubStatusCommand.TOKEN}=token",
+                            "${TeamcityPostGithubStatusCommand.STATE}=success",
+                        ),
+                    ).map { (name, args) -> Arguments.of(name, args) }
+                }.stream()
+        // </editor-fold>
     }
 }

--- a/src/test/kotlin/TeamcityTestConfiguration.kt
+++ b/src/test/kotlin/TeamcityTestConfiguration.kt
@@ -1,5 +1,5 @@
 data class TeamcityTestConfiguration(
     val name: String,
     val host: String,
-    val version: Int
+    val version: Int,
 )


### PR DESCRIPTION
Adopts the octopusden quality-gates convention so every PR is blocked by a mandatory `gate/merge` status check.

## What changed
- **Apply the convention plugin**: `org.octopusden.octopus-quality` (pinned **2.3.5** via `settings.gradle.kts` `pluginManagement`) together with `io.gitlab.arturbosch.detekt` and `org.jlleitschuh.gradle.ktlint` on the single Kotlin module (root project).
- **`octopusQuality {}`**: `coverage { enabled = false }` (no coverage tool configured) and `kotlin { failOnViolation = true }` to enforce Kotlin static analysis.
- **Baselines committed** so the gate is green while enforcing existing debt:
  - `detekt-baseline.xml` — 20 entries.
  - `ktlint-baseline.xml` — after `ktlintFormat`, ktlint violations dropped from **702 → 2** (remaining absorbed by baseline).
- **Merge gate**: new `merge-gate.yml` composes `build` + `quality` + `security` via `workflow_call` and aggregates them into `gate/merge` using the octopus-base `merge-gate` action `@v2.3.5`.
- **Canonical ORMS shape** for `build.yml` / `quality.yml` / `security.yml`: `push: [main]` + `workflow_call` + `workflow_dispatch` (no direct `pull_request`). `build.yml` keeps `flow-type: hybrid`, Java 21.
- **Version pin**: all `octopusden/octopus-base` reusable-workflow refs bumped to `@v2.3.5` (build, quality, security, merge-gate action, check-and-register, release).

## Verification
Local resolution was routed to Maven Central via a throwaway `-I` init script (corporate Artifactory mirror is unreachable from the sandbox; **not committed**). `./gradlew qualityStatic` runs detekt + ktlintCheck (non-hollow — both scan Kotlin and execute) and passes **green** with the committed baselines. GitHub Actions resolves dependencies normally and is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)