### PR TITLE
Lower TeamCity pod CPU requests to fix FT pod scheduling on OKD

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,10 @@ ocTemplate {
                     "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
                     "TEAMCITY_IMAGE_TAG" to properties["teamcity-2022.image-tag"] as String,
                     "TEAMCITY_ID" to "22",
-                    "CPU_REQUEST" to "1000m",
+                    // Requests kept low (limits unchanged) per DevOps: 6-core nodes,
+                    // a ~half-core request is too much to schedule a dev-env app and
+                    // left teamcity22 stuck in Pending on the shared test-env namespace.
+                    "CPU_REQUEST" to "50m",
                     "CPU_LIMIT" to "4000m",
                     "MEM_REQUEST" to "1.5Gi",
                     "MEM_LIMIT" to "3Gi",
@@ -173,7 +176,7 @@ ocTemplate {
                     "SERVICE_ACCOUNT_ANYUID" to project.properties["okd.service-account-anyuid"] as String,
                     "TEAMCITY_IMAGE_TAG" to project.properties["teamcity-2026.image-tag"] as String,
                     "TEAMCITY_ID" to "26",
-                    "CPU_REQUEST" to "200m",
+                    "CPU_REQUEST" to "50m",
                     "CPU_LIMIT" to "2500m",
                     "MEM_REQUEST" to "1.5Gi",
                     "MEM_LIMIT" to "3Gi",


### PR DESCRIPTION
## Problem

FT `[2.0] FT [AUTO]` on OKD was failing with `Pods readiness check attempts exceeded` (task `:ocCreateTeamcityServers`). It was **not** a test failure and **not** related to the CRS v3 migration:

- 0 failed tests / 0 build problems — tests never ran; `comp-reg` (CRS 3.0.4) and `teamcity26` came up healthy.
- The **`teamcity22` pod stayed in `phase=Pending`** and was never scheduled on the shared `test-env` namespace, then timed out. The captured pod-log artifact is 0 bytes (container never started).
- Identical signature across builds 543 / 544 / 545. The manifest was unchanged from the last green build (534), so this is namespace capacity contention, not a repo regression: `teamcity22`'s CPU request (`1000m`) could not be scheduled while `teamcity26` (`200m`) could.

## Change

Per DevOps recommendation (nodes are 6 cores, so a ~half-core request is too much to schedule a dev-env app), lower `CPU_REQUEST` to `50m` for both TeamCity servers:

- teamcity22: `1000m → 50m`
- teamcity26: `200m → 50m`

CPU limits (`4000m` / `2500m`) are left unchanged — scheduling gates on requests, not limits; memory untouched.

## Verification

FT on branch `fix/ft-okd-cpu-requests` — build `1.0.41-546`: **SUCCESS, 62 tests passed**. `teamcity22` now schedules and the suite runs to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)