### PR TITLE
ci: move octopus-base to v2.7.0 and adopt the shared publication policy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.7.0
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/teamcity/octopus-teamcity-automation/_VER_/octopus-teamcity-automation-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.7.0
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.7.0
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality.coverage.enabled = false), so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.7.0
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.7.0
     with:
       java-version: '21'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -466,4 +466,3 @@ tasks.distZip.get().isEnabled = false
 tasks.shadowDistZip.get().isEnabled = false
 tasks.distTar.get().isEnabled = false
 tasks.shadowDistTar.get().isEnabled = false
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,30 @@ plugins {
 }
 
 octopusQuality {
+    // Regression guard on what this repository publishes to Maven Central, provided by the
+    // shared policy from octopus-base v2.7.0 — this repository used to hand-roll the identical
+    // task, which is why the local copy is deleted in this same commit: two tasks of one name
+    // fail configuration.
+    //
+    // The identity is a COMPOSITE key — path, publication name, coordinate, sorted artifact
+    // signatures — not just the path. In a single-module repository a path-based allowlist is
+    // nearly useless: the set is `{":"}` whatever happens, so a SECOND publication on the root
+    // would leave it unchanged. The signatures matter here specifically: release.yml exempts
+    // EVERY file under the allowlisted artifactId, so a second oversized artifact added to this
+    // publication would otherwise pass both this guard and that one.
+    //
+    // The purpose is the inverse of the deployable case: not to keep the fat jar out — it is
+    // published on purpose and exempted in release.yml — but to catch a coordinate the allowlist
+    // does not cover, which would fail the release or slip onto Central unnoticed if it is small.
+    publication {
+        enforceCentralPublications.set(true)
+        centralPublications.set(
+            setOf(
+                ":|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation|" +
+                    "[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]",
+            ),
+        )
+    }
     // Repo has no coverage tool configured — disable coverage verification.
     coverage {
         enabled.set(false)
@@ -443,93 +467,3 @@ tasks.shadowDistZip.get().isEnabled = false
 tasks.distTar.get().isEnabled = false
 tasks.shadowDistTar.get().isEnabled = false
 
-// Regression guard on what this repository publishes to Maven Central.
-//
-// The identity is a COMPOSITE key — project path, publication name, the coordinate, and the
-// sorted artifact signatures (extension and classifier) — not just the project path. In a single-module repository a path-based allowlist is nearly useless: the set
-// of publishing project paths is `{":"}` whatever happens, so adding a SECOND publication to the
-// root leaves it unchanged and the check passes. That was found by demonstrating the guard rather
-// than by reading it.
-//
-// The purpose here is the inverse of the deployable case: not to keep the fat jar out — it is
-// published on purpose and exempted in release.yml — but to catch a second coordinate appearing,
-// one the allowlist does not cover, which would either fail the release or slip onto Central
-// unnoticed if it happened to be small.
-//
-// allprojects, not subprojects: `subprojects` is empty in a single-module repository, so a
-// subprojects-based check would pass unconditionally and prove nothing.
-val centralPublishedPublications = setOf(
-    ":|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation|" +
-        "[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]",
-)
-
-fun centralPublicationPolicyProblems(): List<String> {
-    // Reading `publishing` throws on a project without maven-publish, so check the plugin first.
-    val actual = allprojects
-        .filter { it.plugins.hasPlugin("maven-publish") }
-        .flatMap { proj ->
-            proj.extensions
-                .getByType(PublishingExtension::class.java)
-                .publications
-                .withType(MavenPublication::class.java)
-                .map { pub ->
-                    // The ARTIFACT SIGNATURES are part of the identity, not just the coordinate.
-                    // Without them the key cannot see a classifier being added to an existing
-                    // publication — and this publication already carries an extra artifact
-                    // (`artifact(metarunners)`), so that is a realistic change, not a hypothetical.
-                    // It matters here specifically because the release-time allowlist exempts
-                    // EVERY file published under the allowlisted artifactId, not only the -all.jar:
-                    // a second oversized artifact added to this publication would otherwise pass
-                    // both this guard and that one.
-                    val signatures = pub.artifacts
-                        .map { a -> listOfNotNull(a.extension, a.classifier).joinToString(":") }
-                        .sorted()
-                    "${proj.path}|${pub.name}|${pub.groupId}:${pub.artifactId}|$signatures"
-                }
-        }.toSet()
-    return if (actual != centralPublishedPublications) {
-        listOf(
-            "Maven Central publication set drifted.\n" +
-                "  allowlisted: ${centralPublishedPublications.sorted()}\n" +
-                "  publishing:  ${actual.sorted()}\n" +
-                "A coordinate not covered by fat-jar-publication-allowlist in release.yml would " +
-                "fail the release, or reach Central unnoticed if it is small.",
-        )
-    } else {
-        emptyList()
-    }
-}
-
-// A policy violation must fail its own gate, not every Gradle invocation: throwing at
-// configuration time would break build, test, dependencies and IDE sync as well.
-val verifyCentralPublicationPolicy =
-    tasks.register("verifyCentralPublicationPolicy") {
-        group = "verification"
-        description = "Fails if the set of projects publishing to Maven Central drifts from the allowlist."
-        doLast {
-            val problems = centralPublicationPolicyProblems()
-            if (problems.isNotEmpty()) {
-                throw GradleException(problems.joinToString("\n\n"))
-            }
-        }
-    }
-
-// Hook the task TYPE, so a concrete task such as publishMavenPublicationToMavenLocal cannot
-// bypass the guard; the aggregates are matched by name as well because `publish` is per-project
-// and `publishToSonatype` only exists with -Pnexus, so neither can be forced into existence.
-// `check` — so the ordinary PR gate covers this. Wired only to the publish path, the guard was
-// never executed by any pull-request check: drift could be merged and would surface at the next
-// release instead of in review. Verified with `./gradlew check --dry-run`, which scheduled the task
-// 0 times before this line and 1 after.
-tasks.named("check") { dependsOn(verifyCentralPublicationPolicy) }
-
-gradle.projectsEvaluated {
-    allprojects {
-        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
-            dependsOn(verifyCentralPublicationPolicy)
-        }
-        tasks
-            .matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
-            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
-    }
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
         id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
         id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
         id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint-gradle.version"] as String)
-        id("org.octopusden.octopus-quality") version "2.6.2"
+        id("org.octopusden.octopus-quality") version "2.7.0"
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
## What

Two changes that must land in the same commit:

- all six `octopus-base` refs and the inline quality-plugin version in `settings.gradle.kts` move to **v2.7.0**;
- the hand-rolled `verifyCentralPublicationPolicy` (90 lines in `build.gradle.kts`) is **deleted** and replaced by `octopusQuality { publication { … } }`, which v2.7.0 provides.

## Why the two cannot be split

octopus-base v2.7.0's quality plugin registers a task named exactly `verifyCentralPublicationPolicy`. Two tasks of one name fail configuration, so bumping first and removing the local copy afterwards breaks the build in between. This is not tidy-up that could follow in a later PR.

The declared set transfers **verbatim**: the shared policy uses the same composite identity (`path|publicationName|group:artifact|[sorted extension:classifier]`) that this repository's local guard used, because the plugin was derived from this guard.

## This PR was repurposed, not newly opened

It was opened 2026-07-28 to bump v2.4.1 → v2.5.2. `main` has since moved to v2.6.2, so **merging it as it stood would have downgraded the pins**, dropping the publication guard (v2.6.0) and built-commit tagging (v2.6.2) — while its title advertised "restores Maven Central release". Reset onto `main` and reused rather than opening a second PR.

## Verification

Run locally against the real v2.7.0 plugin resolved from Maven Central, which also confirms the freshly published plugin is consumable:

- **GREEN** — `./gradlew verifyCentralPublicationPolicy` passes with the declared set.
- **RED** — dropping `zip:metarunners` from the declared set fails the task:
  ```
  Maven Central publication set drifted.
    declared:   [:|maven|…:octopus-teamcity-automation|[jar, jar:all, jar:javadoc, jar:sources]]
    publishing: [:|maven|…:octopus-teamcity-automation|[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]]
  ```
  A guard that cannot fail is worth nothing, so this half is the one that matters.
- `./gradlew check --dry-run` schedules the task **once** — an ordinary PR gate covers it, not only the release path.

## Not verified here

The release path itself is unchanged by this PR and is not exercised by its checks; `fat-jar-publication-allowlist: octopus-teamcity-automation` in `release.yml` is carried over untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build, release, quality, security, and merge validation automation to the latest shared workflow standards.
  - Updated project quality tooling for more consistent analysis and verification.
  - Streamlined Maven Central publication checks, including artifact signature validation.
  - No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->