### PR TITLE
ci: move octopus-base to v2.6.2, carry the fat-jar exception, and guard the publication set

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-build.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'

--- a/.github/workflows/check-and-register.yml
+++ b/.github/workflows/check-and-register.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-check-and-register-release.yml@v2.6.2
     if:  "${{ github.event.workflow_run.conclusion == 'success' }}"
     with:
       artifact-pattern: "octopus/automation/teamcity/octopus-teamcity-automation/_VER_/octopus-teamcity-automation-_VER_.jar"

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -25,6 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.4.1
+      - uses: octopusden/octopus-base/.github/actions/merge-gate@v2.6.2
         with:
           needs: ${{ toJson(needs) }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-quality-gates.yml@v2.6.2
     with:
       java-version: '21'
       # Coverage is disabled for this repo (octopusQuality.coverage.enabled = false), so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,26 @@ on:
 
 jobs:
   build:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-release.yml@v2.6.2
     with:
       flow-type: hybrid
       java-version: '21'
       commit-hash: ${{ github.event.client_payload.commit }}
       build-version: ${{ github.event.client_payload.project_version }}
+      # Exempt from the Maven Central publication guard that v2.6.x adds. This repository
+      # publishes one coordinate, and its -all.jar (24.18 MB) trips the guard twice — on the
+      # shadow classifier and on the 8 MB size limit. It must keep publishing because the
+      # metarunners this repository itself ships download it from a Maven repository and run
+      # it: the published metarunners.zip resolves
+      #   ${group}:octopus-teamcity-automation:${version}:jar:all
+      # and then executes `java -jar …-all.jar` (metarunners/OctopusTeamcityAutomation.xml,
+      # with the coordinate substituted at build time by the zipMetarunners task). Six of the
+      # seven metarunners run through that one, so dropping the classifier would break the
+      # build-chain creation, parameter updates, commit-status posting and VCS-root
+      # replacement that other repositories depend on.
+      #
+      # max-central-artifact-mb is deliberately left at its default rather than raised: the
+      # thin jar and the sources/javadoc artifacts are all far below it, so raising the limit
+      # would weaken the guard for them to accommodate this one artifact.
+      fat-jar-publication-allowlist: octopus-teamcity-automation
     secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security:
-    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.4.1
+    uses: octopusden/octopus-base/.github/workflows/common-java-gradle-security-reports.yml@v2.6.2
     with:
       java-version: '21'
     secrets: inherit

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -445,8 +445,8 @@ tasks.shadowDistTar.get().isEnabled = false
 
 // Regression guard on what this repository publishes to Maven Central.
 //
-// The identity is a COMPOSITE key — project path, publication name, and the coordinate — not just
-// the project path. In a single-module repository a path-based allowlist is nearly useless: the set
+// The identity is a COMPOSITE key — project path, publication name, the coordinate, and the
+// sorted artifact signatures (extension and classifier) — not just the project path. In a single-module repository a path-based allowlist is nearly useless: the set
 // of publishing project paths is `{":"}` whatever happens, so adding a SECOND publication to the
 // root leaves it unchanged and the check passes. That was found by demonstrating the guard rather
 // than by reading it.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -517,6 +517,12 @@ val verifyCentralPublicationPolicy =
 // Hook the task TYPE, so a concrete task such as publishMavenPublicationToMavenLocal cannot
 // bypass the guard; the aggregates are matched by name as well because `publish` is per-project
 // and `publishToSonatype` only exists with -Pnexus, so neither can be forced into existence.
+// `check` — so the ordinary PR gate covers this. Wired only to the publish path, the guard was
+// never executed by any pull-request check: drift could be merged and would surface at the next
+// release instead of in review. Verified with `./gradlew check --dry-run`, which scheduled the task
+// 0 times before this line and 1 after.
+tasks.named("check") { dependsOn(verifyCentralPublicationPolicy) }
+
 gradle.projectsEvaluated {
     allprojects {
         tasks.withType(AbstractPublishToMaven::class.java).configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -442,3 +442,67 @@ tasks.distZip.get().isEnabled = false
 tasks.shadowDistZip.get().isEnabled = false
 tasks.distTar.get().isEnabled = false
 tasks.shadowDistTar.get().isEnabled = false
+
+// Regression guard: the set of projects publishing to Maven Central must not drift. Here the
+// allowlist is the ROOT project — this is a single-module repository, so the one published
+// coordinate comes from ":" itself rather than from a subproject.
+//
+// The point of the guard in a repository that legitimately publishes a 24 MB shadow jar is the
+// opposite of the deployable case: it is not there to keep the fat jar out, it is there to catch
+// a SECOND coordinate appearing. Only the allowlisted artifactId is exempted from the release-time
+// guard, so a new publication would fail the release rather than quietly reach Central.
+//
+// allprojects, not subprojects: in a single-module repository `subprojects` is empty, so a
+// subprojects-based check here would pass unconditionally and prove nothing.
+val centralPublishedProjects = setOf(":")
+
+fun centralPublicationPolicyProblems(): List<String> {
+    // Reading `publishing` throws on a project without maven-publish, so check the plugin first.
+    val publishingProjects = allprojects.filter { candidate ->
+        candidate.plugins.hasPlugin("maven-publish") &&
+            candidate.extensions
+                .getByType(PublishingExtension::class.java)
+                .publications
+                .isNotEmpty()
+    }
+    val actual = publishingProjects.map { it.path }.toSet()
+    return if (actual != centralPublishedProjects) {
+        listOf(
+            "Maven Central publication set drifted.\n" +
+                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
+                "  publishing:  ${actual.sorted()}\n" +
+                "A new coordinate is not covered by fat-jar-publication-allowlist in release.yml " +
+                "and would fail the release, or reach Central unnoticed if it is small.",
+        )
+    } else {
+        emptyList()
+    }
+}
+
+// A policy violation must fail its own gate, not every Gradle invocation: throwing at
+// configuration time would break build, test, dependencies and IDE sync as well.
+val verifyCentralPublicationPolicy =
+    tasks.register("verifyCentralPublicationPolicy") {
+        group = "verification"
+        description = "Fails if the set of projects publishing to Maven Central drifts from the allowlist."
+        doLast {
+            val problems = centralPublicationPolicyProblems()
+            if (problems.isNotEmpty()) {
+                throw GradleException(problems.joinToString("\n\n"))
+            }
+        }
+    }
+
+// Hook the task TYPE, so a concrete task such as publishMavenPublicationToMavenLocal cannot
+// bypass the guard; the aggregates are matched by name as well because `publish` is per-project
+// and `publishToSonatype` only exists with -Pnexus, so neither can be forced into existence.
+gradle.projectsEvaluated {
+    allprojects {
+        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+            dependsOn(verifyCentralPublicationPolicy)
+        }
+        tasks
+            .matching { it.name in setOf("publishToSonatype", "publish", "publishToMavenLocal") }
+            .configureEach { dependsOn(verifyCentralPublicationPolicy) }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -443,36 +443,43 @@ tasks.shadowDistZip.get().isEnabled = false
 tasks.distTar.get().isEnabled = false
 tasks.shadowDistTar.get().isEnabled = false
 
-// Regression guard: the set of projects publishing to Maven Central must not drift. Here the
-// allowlist is the ROOT project — this is a single-module repository, so the one published
-// coordinate comes from ":" itself rather than from a subproject.
+// Regression guard on what this repository publishes to Maven Central.
 //
-// The point of the guard in a repository that legitimately publishes a 24 MB shadow jar is the
-// opposite of the deployable case: it is not there to keep the fat jar out, it is there to catch
-// a SECOND coordinate appearing. Only the allowlisted artifactId is exempted from the release-time
-// guard, so a new publication would fail the release rather than quietly reach Central.
+// The identity is a COMPOSITE key — project path, publication name, and the coordinate — not just
+// the project path. In a single-module repository a path-based allowlist is nearly useless: the set
+// of publishing project paths is `{":"}` whatever happens, so adding a SECOND publication to the
+// root leaves it unchanged and the check passes. That was found by demonstrating the guard rather
+// than by reading it.
 //
-// allprojects, not subprojects: in a single-module repository `subprojects` is empty, so a
-// subprojects-based check here would pass unconditionally and prove nothing.
-val centralPublishedProjects = setOf(":")
+// The purpose here is the inverse of the deployable case: not to keep the fat jar out — it is
+// published on purpose and exempted in release.yml — but to catch a second coordinate appearing,
+// one the allowlist does not cover, which would either fail the release or slip onto Central
+// unnoticed if it happened to be small.
+//
+// allprojects, not subprojects: `subprojects` is empty in a single-module repository, so a
+// subprojects-based check would pass unconditionally and prove nothing.
+val centralPublishedPublications = setOf(
+    ":|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation",
+)
 
 fun centralPublicationPolicyProblems(): List<String> {
     // Reading `publishing` throws on a project without maven-publish, so check the plugin first.
-    val publishingProjects = allprojects.filter { candidate ->
-        candidate.plugins.hasPlugin("maven-publish") &&
-            candidate.extensions
+    val actual = allprojects
+        .filter { it.plugins.hasPlugin("maven-publish") }
+        .flatMap { proj ->
+            proj.extensions
                 .getByType(PublishingExtension::class.java)
                 .publications
-                .isNotEmpty()
-    }
-    val actual = publishingProjects.map { it.path }.toSet()
-    return if (actual != centralPublishedProjects) {
+                .withType(MavenPublication::class.java)
+                .map { "${proj.path}|${it.name}|${it.groupId}:${it.artifactId}" }
+        }.toSet()
+    return if (actual != centralPublishedPublications) {
         listOf(
             "Maven Central publication set drifted.\n" +
-                "  allowlisted: ${centralPublishedProjects.sorted()}\n" +
+                "  allowlisted: ${centralPublishedPublications.sorted()}\n" +
                 "  publishing:  ${actual.sorted()}\n" +
-                "A new coordinate is not covered by fat-jar-publication-allowlist in release.yml " +
-                "and would fail the release, or reach Central unnoticed if it is small.",
+                "A coordinate not covered by fat-jar-publication-allowlist in release.yml would " +
+                "fail the release, or reach Central unnoticed if it is small.",
         )
     } else {
         emptyList()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -459,7 +459,8 @@ tasks.shadowDistTar.get().isEnabled = false
 // allprojects, not subprojects: `subprojects` is empty in a single-module repository, so a
 // subprojects-based check would pass unconditionally and prove nothing.
 val centralPublishedPublications = setOf(
-    ":|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation",
+    ":|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation|" +
+        "[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]",
 )
 
 fun centralPublicationPolicyProblems(): List<String> {
@@ -471,7 +472,20 @@ fun centralPublicationPolicyProblems(): List<String> {
                 .getByType(PublishingExtension::class.java)
                 .publications
                 .withType(MavenPublication::class.java)
-                .map { "${proj.path}|${it.name}|${it.groupId}:${it.artifactId}" }
+                .map { pub ->
+                    // The ARTIFACT SIGNATURES are part of the identity, not just the coordinate.
+                    // Without them the key cannot see a classifier being added to an existing
+                    // publication — and this publication already carries an extra artifact
+                    // (`artifact(metarunners)`), so that is a realistic change, not a hypothetical.
+                    // It matters here specifically because the release-time allowlist exempts
+                    // EVERY file published under the allowlisted artifactId, not only the -all.jar:
+                    // a second oversized artifact added to this publication would otherwise pass
+                    // both this guard and that one.
+                    val signatures = pub.artifacts
+                        .map { a -> listOfNotNull(a.extension, a.classifier).joinToString(":") }
+                        .sorted()
+                    "${proj.path}|${pub.name}|${pub.groupId}:${pub.artifactId}|$signatures"
+                }
         }.toSet()
     return if (actual != centralPublishedPublications) {
         listOf(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
         id("org.octopusden.octopus.oc-template") version (ocTemplatePluginVersion)
         id("io.gitlab.arturbosch.detekt") version (extra["detekt.version"] as String)
         id("org.jlleitschuh.gradle.ktlint") version (extra["ktlint-gradle.version"] as String)
-        id("org.octopusden.octopus-quality") version "2.4.1"
+        id("org.octopusden.octopus-quality") version "2.6.2"
     }
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
## What

Brings this repository under the shared pipeline's Maven Central publication guard, and guards its own publication set. Every `octopus-base` reference moves to **v2.6.2**.

Part of the organisation's Maven Central limits work (octopusden/octopus-base#163).

## This is not a reduction, and does not pretend to be

Measured with the footprint script, which publishes to a throwaway local repository and reads the real coordinates back: **one coordinate, 70 files, 24.47 MB per release, ~1 release a month.** Nothing is dropped here, and nothing should be.

`octopus-teamcity-automation-<ver>-all.jar` (24.18 MB) **must keep publishing**. The metarunners this repository itself ships resolve it from a Maven repository and then execute it:

```
-Dartifact=${group}:${name}:${version}:jar:all
… java -jar ./.$name/$name-$version-all.jar
```

That was verified against the **published** `metarunners.zip` rather than the source XML: `zipMetarunners` substitutes the coordinate at build time, and the published artifact contains the resolved line pointing at this repository's own `-all.jar`. Six of the seven metarunners run through that one, so dropping the classifier would break build-chain creation, parameter updates, commit-status posting and VCS-root replacement in other repositories.

## The guard exception

From v2.6.0 the shared release workflow fails a release when a published artifact carries a shadow classifier or exceeds `max-central-artifact-mb` (default 8). The `-all.jar` trips **both**. Without an exception, the first release after any bump past v2.6.0 would fail — so `release.yml` now names it in `fat-jar-publication-allowlist`.

`max-central-artifact-mb` is deliberately left at its default rather than raised: the thin jar and the sources/javadoc artifacts are far below it, and raising the limit to accommodate one artifact would weaken the guard for the rest.

This matters sooner than it looks: the fix for the Windows quoting defect in the shared commit-status recipe (octopusden/octopus-teamcity-automation#69) will need a release of this repository to take effect. If the pins move past v2.6.0 without this exception, that release fails on the guard.

## The in-repo guard, and a finding worth reading

The purpose here is the **inverse** of the deployable case. It is not there to keep the fat jar out — that jar is published on purpose — but to catch a **second coordinate** appearing, one the allowlist does not cover, which would either fail the release or slip onto Central unnoticed if it happened to be small.

The first version of the guard allowlisted **project paths**, matching the other repositories in this rollout. Demonstrating it showed that is nearly useless here: in a single-module repository the set of publishing project paths is `{":"}` whatever happens, so a second publication added to the root left it unchanged and the check passed. The only drift a path-based check could notice is "the root stopped publishing", and that case cannot even be reached — the `signing` block references the publication by name, so removing it fails configuration first.

The identity is now **path + publication name + coordinate + the sorted artifact signatures** (extension and classifier). The first three alone — the form shipped in the dms-service cleanup — were still too weak here, which independent review caught: they do not change when an artifact is *added* to an existing publication, and this publication already carries an extra one (`artifact(metarunners)`). That gap mattered more here than elsewhere, because the release-time allowlist exempts **every** file published under the allowlisted artifactId, not only the `-all.jar` — so a second oversized artifact would have passed both guards. The expected set is now explicit: `[jar, jar:all, jar:javadoc, jar:sources, zip:metarunners]`.

What it still does not catch, stated rather than left implied: the **version** is deliberately excluded, since every release changes it. So this is a publication-identity-and-shape guard, not proof that a given release is well-formed. This was found by demonstrating the guard, not by reading it — which is the argument for requiring the demonstration.

```
# RED — a second publication in the same, allowlisted project
> Maven Central publication set drifted.
    allowlisted: [:|maven|org.octopusden.octopus.automation.teamcity:octopus-teamcity-automation]
    publishing:  [:|maven|…:octopus-teamcity-automation, :|redDemo|…:octopus-teamcity-automation]

# the leaf publish task of it cannot bypass the guard either
./gradlew publishRedDemoPublicationToMavenLocal
> Task :verifyCentralPublicationPolicy FAILED

# unrelated work is unaffected while the violation is present
./gradlew help -> exit 0

# GREEN — after reverting
./gradlew verifyCentralPublicationPolicy -> BUILD SUCCESSFUL
```

It iterates `allprojects` for the same reason paths were not enough: `subprojects` is empty in a single-module repository, so a subprojects-based check would pass unconditionally and prove nothing. And it is a task rather than a configuration-time throw, which would break `build`, `test`, `dependencies` and IDE sync the moment the set drifted.

## Verified locally

- `./gradlew build verifyCentralPublicationPolicy -x test` — green, with the guard task executing.
- **`test` excluded — and CI does NOT cover it either**, so unit tests are not exercised anywhere for this change. `quality.yml` excludes `test` and the whole compose lifecycle from its `coverage-command` because docker-compose is unavailable on the GitHub runner, and `build.yml` runs `flow-type: hybrid`, where the shared workflow defaults `skip-tests` to `true`. An earlier revision of this text claimed CI would cover it; that was wrong. Locally the task requires a docker-compose stack whose `teamcity-2022` and `components-registry-service` images are amd64-only. On an arm64 machine the container never becomes healthy — 37 minutes, then `Container … of teamcity-2022-1 is still reported as 'unhealthy'`. Unrelated to this change, which touches version pins and adds a verification task.
- The red/green demonstration above, on the pushed state, with the worktree left clean afterwards.
- The `octopus-quality` bump is behaviour-neutral: its production sources are identical between v2.4.1 and v2.6.2, and this repository pins `detekt.version=1.23.8` itself, so the bump does not move detekt.

## Not verified, and only a real release can

That the guard passes on a real release with the allowlist honoured. v2.6.2's release path has now been exercised once in the organisation — reporting-service 2.0.5 published this morning with the guard running and passing — but not yet from this repository.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Maven Central publishing safeguard that detects unexpected publication changes.
  * Publishing validation now reports differences between approved and configured artifacts.

* **Chores**
  * Updated build, quality, security, release, and merge validation workflows to newer shared versions.
  * Updated the project quality plugin to improve validation and workflow checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
