### PR TITLE
fix(metarunners): quote GitHub status context/description for Windows  agents

### DIFF
--- a/metarunners/PostGithubCommitStatus.xml
+++ b/metarunners/PostGithubCommitStatus.xml
@@ -21,7 +21,7 @@
         <build-runners>
             <runner name="post github status" type="OctopusTeamcityAutomation">
                 <parameters>
-                    <param name="ARGS" value="--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% post-github-status --owner=%GITHUB_OWNER% --repo=%GITHUB_REPO% --commit=%COMMIT_SHA% --token=%OCTOPUS_GITHUB_TOKEN% --state=%COMMIT_STATUS_STATE% --context='%COMMIT_STATUS_CONTEXT%' --description='%COMMIT_STATUS_DESCRIPTION%' --github-api-url=%GITHUB_API_URL%"/>
+                    <param name="ARGS" value='--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% post-github-status --owner=%GITHUB_OWNER% --repo=%GITHUB_REPO% --commit=%COMMIT_SHA% --token=%OCTOPUS_GITHUB_TOKEN% --state=%COMMIT_STATUS_STATE% --context="%COMMIT_STATUS_CONTEXT%" --description="%COMMIT_STATUS_DESCRIPTION%" --github-api-url=%GITHUB_API_URL%'/>
                 </parameters>
             </runner>
         </build-runners>


### PR DESCRIPTION
The post-github-status metarunner wrapped COMMIT_STATUS_CONTEXT and COMMIT_STATUS_DESCRIPTION in single quotes. Single quotes are POSIX shell syntax only: on a Windows agent the step runs as a .cmd and java.exe splits its command line with Windows CRT rules, where ' is an ordinary character. A context such as "TeamCity / PR Validation" therefore reached the CLI as four arguments and parsing failed with "got unexpected extra argument".

Use double quotes, the only quoting honoured by both POSIX shells and Windows cmd/java.exe, so the values arrive as single arguments on either platform. Switch the XML attribute delimiter to single quotes to keep the double quotes readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub commit status updates by ensuring context and description values are handled correctly when passed to the status runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->