### PR TITLE
Set env.JAVA_HOME parameter on CreateTeamCityBuildChain

### DIFF
--- a/docs/tech-debt/TD-001-jdk-version-param-removal.md
+++ b/docs/tech-debt/TD-001-jdk-version-param-removal.md
@@ -1,0 +1,40 @@
+# TD-001: Remove the `JDK_VERSION` build-type parameter from `create-build-chain`
+
+## Status
+
+Open.
+
+## Context
+
+`TeamcityCreateBuildChainCommand.createBuildChain()` sets a `JDK_VERSION` build-type parameter
+on the compile build config only, derived from the component-registry's `javaVersion` field
+(e.g. `"1.8"`, `"11"`). It's a bare version string, useful only if a build template downstream
+knows how to turn it into a JDK path.
+
+The same command now also resolves and always writes an `env.JAVA_HOME` **project**-level
+parameter — a proper TeamCity parameter reference (e.g. `%env.JDK_17_0%`) inherited by every
+build config in the chain, not just compile. `JDK_VERSION` is kept only so teams still consuming
+it don't break; both parameters are set side by side for now.
+
+## Symptoms (when this will hurt)
+
+- Every `create-build-chain` run resolves and writes two parameters for one concept ("which JDK
+  to use") once all consumers have migrated to `env.JAVA_HOME`.
+- A future contributor may treat `JDK_VERSION` as load-bearing and build on top of it, deepening
+  the duplication this item exists to remove.
+
+## Acceptance criteria
+
+1. Confirm no build template still reads `%JDK_VERSION%` — all consume `%env.JAVA_HOME%`.
+2. Remove the `JDK_VERSION`-setting block in
+   `TeamcityCreateBuildChainCommand.kt::createBuildChain`.
+3. Remove or update `ApplicationTest.kt::testTeamCityCreateBuildChainForJDKVersion`.
+
+No specific date — this is consumer-migration-gated, not time-gated.
+
+## Related
+
+- `src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt` —
+  both parameters are set in `createBuildChain`.
+- `src/test/kotlin/ApplicationTest.kt::testTeamCityCreateBuildChainForJDKVersion` — current
+  coverage of the parameter being removed.

--- a/metarunners/CreateTeamCityBuildChain.xml
+++ b/metarunners/CreateTeamCityBuildChain.xml
@@ -8,11 +8,12 @@
             <param name="MINOR_VERSION" value="%MINOR_VERSION%" />
             <param name="CREATE_CHECKLIST" value="%CREATE_CHECKLIST%" />
             <param name="CREATE_RC_FORCE" value="%CREATE_RC_FORCE%" />
+            <param name="JAVA_HOME_MAPPING" value="" spec="text description='Optional env.JAVA_HOME mapping: a leading template (e.g. env.JDK_{major}_0) plus optional major=name overrides, comma/semicolon separated. Leave empty to skip.' display='normal'" />
         </parameters>
         <build-runners>
             <runner name="create build chain" type="OctopusTeamcityAutomation">
                 <parameters>
-                    <param name="ARGS" value="--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% create-build-chain --registry-url=%COMPONENT_REGISTRY_URL% --parent-project-id=%TEAMCITY_PARENT_PROJECT_ID% --component=%COMPONENT_NAME% --minor-version=%MINOR_VERSION% --create-checklist=%CREATE_CHECKLIST% --create-rc-force=%CREATE_RC_FORCE% " />
+                    <param name="ARGS" value="--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% create-build-chain --registry-url=%COMPONENT_REGISTRY_URL% --parent-project-id=%TEAMCITY_PARENT_PROJECT_ID% --component=%COMPONENT_NAME% --minor-version=%MINOR_VERSION% --create-checklist=%CREATE_CHECKLIST% --create-rc-force=%CREATE_RC_FORCE% --java-home-mapping=%JAVA_HOME_MAPPING% " />
                 </parameters>
             </runner>
         </build-runners>

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -1,8 +1,8 @@
 ## Context
 
 - `TeamcityCreateBuildChainCommand.createBuildChain()`
-  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt:107-110`)
-  already has the shape this change extends:
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`)
+  had this shape before this change:
 
   ```kotlin
   val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
@@ -17,11 +17,15 @@
 - `SPLIT_SYMBOLS = "[,;]"` (`Application.kt:5`) is the existing convention for CLI options that
   accept multiple delimited values, already used by `TeamcityUpdateParameterCommand` for
   comma/semicolon-separated ID lists.
-- `setBuildTypeParameter` and `setProjectParameter`
-  (`TeamcityCreateBuildChainCommand.kt:220-234`) are the two existing helpers for writing
-  TeamCity parameters, at build-type and project scope respectively; this change is the first
-  caller of `setProjectParameter` for something other than
-  `COMPONENT_NAME`/`PROJECT_VERSION`.
+- `setBuildTypeParameter` and `setProjectParameter` were the two pre-existing helpers for
+  writing TeamCity parameters, at build-type and project scope respectively. This change was
+  the first caller needing `setProjectParameter` for something other than
+  `COMPONENT_NAME`/`PROJECT_VERSION` — during implementation the two were merged into a single
+  `setParameter(configurationType: ConfigurationType, id: String, name: String, value: String)`
+  (they differed only in `ConfigurationType` and one word of log text), freeing a function slot
+  needed to keep `resolveJavaHome` (Decision 9) as a class member without tripping detekt's
+  `TooManyFunctions` limit. All call sites, including the pre-existing `JDK_VERSION` one, use
+  the merged helper now.
 
 ## Worked example
 
@@ -154,11 +158,12 @@ Takeaways:
 
 ### 9. `env.JAVA_HOME` is always written: mapping resolution, else the parent's value, else an empty string
 
-- `setProjectParameter(project.id, "env.JAVA_HOME", ...)` is called exactly once per
-  `createBuildChain` run, with no guard. The value is, in order: the mapping's resolution
-  (Decision 4), the parent's existing `env.JAVA_HOME`
+- `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(...))`
+  is called exactly once per `createBuildChain` run, with no guard. `resolveJavaHome` is a
+  private member of `TeamcityCreateBuildChainCommand` returning, in order: the mapping's
+  resolution wrapped as `%...%` (Decision 4), the parent's existing `env.JAVA_HOME`
   (`client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")` — the same lookup pattern
-  `JDK_VERSION`'s default already uses), or `""`.
+  `JDK_VERSION`'s default already uses, used as-is, not re-wrapped), or `""`.
 - Scope: every project this tool creates ends up with the `env.JAVA_HOME` parameter present,
   ready to be filled in directly in TeamCity if nothing else supplied a value. See Risks below
   for the trade-off this implies for an already-working parent-level setup.
@@ -167,9 +172,9 @@ Takeaways:
 
 - `JDK_VERSION` is only ever set on the compile build-type (`compileConfig.id`), and only when
   it differs from the project default. `env.JAVA_HOME` is instead set on the newly created
-  component project (`project.id`) via `setProjectParameter`, so it's inherited by every build
-  config under that project (compile, RC, checklist, release) — not just the compile step,
-  since release/RC builds can also need a JDK on the agent.
+  component project (`project.id`), so it's inherited by every build config under that project
+  (compile, RC, checklist, release) — not just the compile step, since release/RC builds can
+  also need a JDK on the agent.
 - Unlike `JDK_VERSION`'s conditional write, `env.JAVA_HOME` is written every time, with no
   "only if different" or "only if non-empty" guard (Decision 9).
 
@@ -201,7 +206,7 @@ Takeaways:
     component will read the *parent's* value (or fall through to `""`) and overwrite the
     child project's existing value — including blanking it out entirely if the parent has
     nothing configured either.
-  - Accepted because `setProjectParameter` always writes at project-creation time for a
+  - Accepted because this write always happens at project-creation time for a
     project this tool itself just created — there's no established prior art of a human
     hand-editing a freshly-created child project's parameters before this tool finishes, so
     the realistic risk is a *re-run* of `create-build-chain` against an existing project,

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -176,12 +176,13 @@ Takeaways:
 ### 11. `JDK_VERSION` is deprecated but not removed in this change
 
 - Both parameters are set side by side.
-- This repo has no existing tech-debt-tracking convention of its own; the removal condition is
-  recorded here so a future change can find it:
-  - **Remove the `JDK_VERSION`-setting block once all teams currently depending on it have
-    migrated their build templates to consume `%env.JAVA_HOME%` instead of the literal
-    `%JDK_VERSION%` value.**
-  - No specific date — this is consumer-migration-gated, not time-gated.
+- The removal condition is tracked as
+  [`docs/tech-debt/TD-001-jdk-version-param-removal.md`](../../../docs/tech-debt/TD-001-jdk-version-param-removal.md)
+  (this repo's first tech-debt record) rather than only here — a `TD-NNN` file survives this
+  change folder being archived, so the removal condition stays discoverable long after
+  OCTOPUS-2473 itself is history. The code points at the same file via a `TD-001:` comment on
+  the `JDK_VERSION`-setting block.
+- No specific date — this is consumer-migration-gated, not time-gated.
 
 ## Out of Scope
 

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 - `TeamcityCreateBuildChainCommand.createBuildChain()`
@@ -10,6 +12,7 @@
       setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
   }
   ```
+
 - `component.buildParameters` is `BuildParametersDTO` from `components-registry-service-core`,
   whose only Java-related field is `javaVersion: String?` — a plain string like `"1.8"` or
   `"11"`. There is no separate "java" field; the new `env.JAVA_HOME` logic reuses this same

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -1,0 +1,258 @@
+## Context
+
+- `TeamcityCreateBuildChainCommand.createBuildChain()`
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt:107-110`)
+  already has the shape this change extends:
+
+  ```kotlin
+  val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
+  component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
+      setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
+  }
+  ```
+- `component.buildParameters` is `BuildParametersDTO` from `components-registry-service-core`,
+  whose only Java-related field is `javaVersion: String?` — a plain string like `"1.8"` or
+  `"11"`. There is no separate "java" field; the new `env.JAVA_HOME` logic reuses this same
+  field.
+- `SPLIT_SYMBOLS = "[,;]"` (`Application.kt:5`) is the existing convention for CLI options that
+  accept multiple delimited values, already used by `TeamcityUpdateParameterCommand` for
+  comma/semicolon-separated ID lists.
+- `setBuildTypeParameter` and `setProjectParameter`
+  (`TeamcityCreateBuildChainCommand.kt:220-234`) are the two existing helpers for writing
+  TeamCity parameters, at build-type and project scope respectively; this change is the first
+  caller of `setProjectParameter` for something other than
+  `COMPONENT_NAME`/`PROJECT_VERSION`.
+
+## Worked example
+
+Given `parentProjectId = "TeamOctopus"` with an existing project parameter
+`env.JAVA_HOME = "%env.JDK_1_8%"` (the team's org-wide default), and a component whose registry
+entry has `javaVersion = "17"`:
+
+| Invocation | Resolution | Result |
+|---|---|---|
+| no `--java-home-mapping` | mapping empty → fall back to parent | `env.JAVA_HOME = "%env.JDK_1_8%"` (inherited default, ignores the component's actual `javaVersion`) |
+| `--java-home-mapping=8=env.JDK_1_8,11=env.JDK_11_0` (overrides only, no leading template) | **invalid** — a leading template is required whenever the option is supplied at all | command fails before creating any project |
+| `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0` | major `17` not an explicit key → leading template substituted | `env.JAVA_HOME = "%env.JDK_17_0%"` |
+| `--java-home-mapping=env.JDK_{major}_0,17=env.JDK_17_CUSTOM` | major `17` explicit override wins over the template | `env.JAVA_HOME = "%env.JDK_17_CUSTOM%"` |
+| `--java-home-mapping=8=env.JDK_1_8,env.JDK_{major}_0` | **invalid** — a bare entry is only recognized in position 0 | command fails before creating any project |
+
+Takeaways:
+- Row 1: absent the flag entirely, `env.JAVA_HOME` reflects the *parent project's* existing
+  value, not the component's own `javaVersion` — mirroring how `JDK_VERSION`'s fallback already
+  works today (`defaultJDKVersion` is also read from the parent, not derived from the component
+  when absent).
+- Row 2: once the option is supplied, it must always start with the template — there is no
+  "overrides-only" form (see Decision 3).
+- Row 5: a bare entry is a hard failure wherever it isn't in position 0, not a silent fallback
+  or reordering (see Decision 2).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every team using this tool can get a correct `env.JAVA_HOME` reference for their build,
+  regardless of what they've named their agent-side JDK parameters.
+- JDK majors not yet known to this tool (e.g. a future 27) work automatically once a team has
+  supplied a leading template in `--java-home-mapping`, without a code change here — the
+  formula itself is caller data, not a constant in this codebase.
+- No behavior change to `JDK_VERSION` — existing consumers of it are unaffected.
+
+**Non-Goals:**
+- This tool does not become the source of truth for which JDKs exist on which agents — it only
+  ever writes a *reference* (`%env.JDK_x_y%`), never a literal path.
+- No generic "arbitrary TeamCity parameter mapping" feature — this is scoped to
+  `env.JAVA_HOME` specifically.
+- No attempt to auto-discover or validate agent parameter names against a live TeamCity server.
+- No enforcement that a parameter name look like a TeamCity environment-variable reference
+  (e.g. no required `env.` prefix) — see Decision 5.
+
+## Decisions
+
+### 1. Override source is a CLI flag, not a TeamCity project parameter
+
+- Considered reading the mapping from a TeamCity project parameter (mirroring how
+  `defaultJDKVersion` is read), which would let teams edit it in the TeamCity UI without
+  touching pipeline scripts.
+- Rejected because the CLI flag was the user's explicit choice: it keeps the mapping visible
+  and versioned next to the pipeline script that invokes this tool, rather than living as
+  server-side state that's easy to forget exists.
+- Lands in `TeamcityCreateBuildChainCommand`'s companion object as
+  `JAVA_HOME_MAPPING = "--java-home-mapping"`.
+
+### 2. Mapping format reuses `SPLIT_SYMBOLS`; overrides are `key=value`, the template is a bare leading entry
+
+- Considered a JSON object string for more structure, but there is no existing
+  JSON-parsing-from-CLI-string precedent anywhere in this repo, so it would be new machinery
+  for a handful of entries.
+- `key=value` pairs split on `SPLIT_SYMBOLS` matches the exact idiom
+  `TeamcityUpdateParameterCommand` already uses for its ID-list options, so a reader of this
+  file already knows the convention for the override entries.
+- The template entry is deliberately *not* another `key=value` pair (e.g. not
+  `default=env.JDK_{major}_0`) — it's a bare value with no key at all, and it must be the
+  first segment in the option value:
+  `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`.
+- A bare entry appearing anywhere other than position 0 (e.g.
+  `--java-home-mapping=8=env.JDK_1_8,env.JDK_{major}_0`) is a validation error, not silently
+  accepted or reordered — position is the only signal that distinguishes "this is the
+  template" from "this is a malformed override missing its key", so the parser must be strict
+  about it rather than guessing intent.
+
+### 3. The leading template is required whenever the option is supplied
+
+- Considered making the template optional (an overrides-only mapping would then just leave
+  every uncovered major to the parent-project fallback).
+- Overridden after review: a caller who bothers to pass `--java-home-mapping` almost certainly
+  wants a real answer for majors they didn't think to list, not a silent, easy-to-miss fallback
+  to whatever the parent project happens to have. Requiring the template up front forces that
+  choice to be explicit at the call site instead of discovered later as an unexpected `%env.JDK_1_8%`
+  inherited from the parent.
+- `--java-home-mapping=8=env.JDK_1_8,11=env.JDK_11_0` (no leading template) is therefore
+  rejected outright, not treated as "overrides only, no formula" — see the spec's mandatory-template
+  requirement.
+- Omitting the whole option is still fine and unaffected by this decision: no flag at all means
+  no mapping, which is the existing parent-project-fallback path (Decision 6).
+
+### 4. The fallback formula is caller-supplied data (the leading bare entry), not a constant in this codebase
+
+- An earlier version of this design had `env.JDK_{major}_0` (plus a built-in
+  `8 -> env.JDK_1_8` exception) hardcoded in `JavaHomeMapping`, applied whenever an explicit
+  override was missing.
+- Overridden after review: the whole point of making the mapping overridable is that no naming
+  scheme this tool bakes in is guaranteed to hold for every team or every future JDK release —
+  a hardcoded formula is exactly the same class of problem as a hardcoded map, just one level
+  more abstract.
+- Instead, `--java-home-mapping` requires the leading bare entry (Decision 3) whose value is a
+  template containing the placeholder `{major}` (e.g. `env.JDK_{major}_0`), substituted at
+  resolution time.
+- There is now no formula and no built-in exception anywhere in the code — a team that wants
+  the `8 -> env.JDK_1_8` behavior supplies it as an explicit override alongside their own
+  template, exactly like any other override.
+- If resolution has nothing to go on for a given major (this only happens when the whole
+  option was omitted — see Decision 3), it falls through to the parent-project fallback
+  (Decision 6) rather than guessing.
+
+### 5. Override/template values are not required to look like `env.<NAME>`
+
+- An earlier version of this design required every value (override and template) to match
+  `^env\.[A-Za-z0-9_]+$`, rejecting anything not literally prefixed `env.`.
+- Overridden after review: this tool has no way to verify a value actually corresponds to a
+  real TeamCity agent parameter regardless of prefix, so a prefix check only catches one
+  specific typo shape while rejecting otherwise-valid names a team might already be using for
+  a different kind of parameter. Requiring `env.` added a rule this tool can't meaningfully
+  enforce.
+- What's still validated, because these are structural mistakes this tool *can* detect with
+  certainty:
+  - a value must be non-blank;
+  - an override value must not already be `%`-wrapped (a caller who writes `8=%env.JDK_1_8%`
+    almost certainly means `8=env.JDK_1_8` — this tool wraps the value itself);
+  - an override value must not contain the `{major}` placeholder (only the template
+    substitutes it);
+  - the template must contain **exactly one** `{major}` occurrence.
+
+### 6. Placeholder syntax is `{major}`, not the codebase's existing `{}` SLF4J-style convention
+
+- This file already uses `{}` as a placeholder in log messages (e.g.
+  `log.warn("Skip disable build step '{}' not found for build type {}", ...)`), but that
+  convention is for messages a developer reads in a log, not a string a caller writes into a
+  CLI flag.
+- `{major}` is self-documenting for a public-facing option — a caller reading
+  `--java-home-mapping=env.JDK_{major}_0,...` for the first time doesn't need this design doc
+  to understand what gets substituted.
+
+### 7. Major version is derived from `javaVersion`'s trailing segment
+
+- `javaVersion` values from the registry come in two shapes seen in existing fixtures:
+  dotted legacy form (`"1.8"`) and bare modern form (`"11"`, `"17"`, `"21"`, `"25"`).
+- Both shapes SHALL resolve to the same major-version integer used for override lookup and
+  template substitution: take the substring after the last `.`, or the whole string if there
+  is no `.`, then parse as an integer.
+- Examples: `"1.8"` → `8`; `"8"` → `8`; `"11"` → `11`; `"17"` → `17`.
+- This is why `8` needs no built-in exception (Decision 4) — `"1.8"` and a hypothetical
+  override keyed `8=...` already refer to the same major through this extraction rule; the
+  *naming* exception (`env.JDK_1_8` instead of `env.JDK_8_0`) is what still needs an explicit
+  caller-supplied override, not the version-matching itself.
+
+### 8. Eager validation of every mapping entry, not lazy failure at `setParameter` time
+
+- A malformed entry — the option supplied without a leading template, a bare entry anywhere
+  other than position 0, a non-numeric override key, an already-`%`-wrapped value, a value
+  containing `{major}` where it shouldn't, a template missing (or containing more than one)
+  `{major}` placeholder, or a duplicate override key — is rejected at option-parse time with a
+  message naming the specific bad entry.
+- Rejected the alternative of accepting anything and letting a bad reference silently write
+  garbage into TeamCity (e.g. `%%env.JDK_1_8%%` or an unresolvable parameter) — that failure
+  mode would only surface much later, as a broken build, far from the CLI invocation that
+  caused it.
+
+### 9. Fallback to the parent project's existing `env.JAVA_HOME`, not "skip"
+
+- An earlier version of this design had the feature skip entirely (no `env.JAVA_HOME` written)
+  whenever the flag was absent or the component had no `javaVersion`, making it strictly
+  opt-in with zero behavior change for anyone not using the flag.
+- Overridden after review: skipping meant a team that already has `env.JAVA_HOME` configured
+  at the parent-project level (their existing convention, predating this tool) would see it
+  silently absent on every new child project this tool creates, forcing manual re-entry per
+  component.
+- Falling back to `client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")` — the exact
+  same lookup pattern `JDK_VERSION`'s default already uses — means an already-working
+  parent-level setup keeps working with zero flag usage, at the cost of the sharp edge
+  documented in the worked example above (parent value wins over the component's actual
+  `javaVersion` when the option is omitted). This trade-off is accepted; see Risks below.
+
+### 10. Written at project level, not build-type level
+
+- `JDK_VERSION` is only ever set on the compile build-type (`compileConfig.id`).
+  `env.JAVA_HOME` is instead set on the newly created component project (`project.id`) via
+  `setProjectParameter`, so it's inherited by every build config under that project (compile,
+  RC, checklist, release) — not just the compile step, since release/RC builds can also need a
+  JDK on the agent.
+- This is a deliberate behavioral difference from `JDK_VERSION`'s narrower scope, not an
+  inconsistency.
+
+### 11. `JDK_VERSION` is deprecated but not removed in this change
+
+- Both parameters are set side by side.
+- This repo has no existing tech-debt-tracking convention of its own (unlike `octopus-base`'s
+  single-table register or
+  `octopus-components-management-portal-wt/rms-registered-build-params`'s per-item files);
+  rather than inventing one, the removal condition is recorded here as a decision so a future
+  change can find it:
+  - **Remove the `JDK_VERSION`-setting block once all teams currently depending on it have
+    migrated their build templates to consume `%env.JAVA_HOME%` instead of the literal
+    `%JDK_VERSION%` value.**
+  - No specific date — this is consumer-migration-gated, not time-gated.
+
+## Out of Scope
+
+- Any change to how `JDK_VERSION` itself is computed or set (Decision 11) — deferred until
+  consumer migration is confirmed.
+- Reading the mapping from a TeamCity project parameter (Decision 1) — CLI flag only.
+- A hardcoded fallback formula or built-in per-major exceptions (Decision 4) — the leading bare
+  template entry is the only formula mechanism, and it is entirely caller-supplied.
+- Enforcing a required naming prefix (e.g. `env.`) on override or template values (Decision 5).
+
+## Risks / Trade-offs
+
+- **Silent overwrite of an existing `env.JAVA_HOME`.**
+  - If a team already hand-configured `env.JAVA_HOME` on a component's project directly (not
+    on the parent), the next `create-build-chain` run without `--java-home-mapping` for that
+    component will read the *parent's* value (or nothing) and overwrite the child project's
+    existing value.
+  - Accepted because `setProjectParameter` always writes at project-creation time for a
+    project this tool itself just created — there's no established prior art of a human
+    hand-editing a freshly-created child project's parameters before this tool finishes, so
+    the realistic risk is a *re-run* of `create-build-chain` against an existing project,
+    which is not this command's documented use case today.
+  - Called out explicitly in `proposal.md`'s Affected areas so it's visible to reviewers
+    rather than discovered later.
+- **Parent-value-wins-over-actual-`javaVersion` when the option is omitted** (Decision 9).
+  - A component with `javaVersion = "17"` under a parent whose `env.JAVA_HOME` defaults to JDK
+    8 gets JDK 8's reference, not JDK 17's, unless the caller passes `--java-home-mapping` at
+    all (once passed, Decision 3 guarantees a resolution via the required template or an
+    explicit override).
+  - This mirrors `JDK_VERSION`'s existing fallback semantics exactly, so it's consistent with
+    prior behavior in this file, but it means the new parameter alone doesn't guarantee
+    "correct JDK for this component" — passing the mapping does.
+  - Worth flagging to a new user of this flag: not passing `--java-home-mapping` at all
+    silently falls back to the parent for every component, which can look like "the feature
+    isn't doing anything" if not understood.

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -17,15 +17,13 @@
 - `SPLIT_SYMBOLS = "[,;]"` (`Application.kt:5`) is the existing convention for CLI options that
   accept multiple delimited values, already used by `TeamcityUpdateParameterCommand` for
   comma/semicolon-separated ID lists.
-- `setBuildTypeParameter` and `setProjectParameter` were the two pre-existing helpers for
-  writing TeamCity parameters, at build-type and project scope respectively. This change was
-  the first caller needing `setProjectParameter` for something other than
-  `COMPONENT_NAME`/`PROJECT_VERSION` — during implementation the two were merged into a single
-  `setParameter(configurationType: ConfigurationType, id: String, name: String, value: String)`
-  (they differed only in `ConfigurationType` and one word of log text), freeing a function slot
-  needed to keep `resolveJavaHome` (Decision 9) as a class member without tripping detekt's
-  `TooManyFunctions` limit. All call sites, including the pre-existing `JDK_VERSION` one, use
-  the merged helper now.
+- `setBuildTypeParameter` and `setProjectParameter` were two pre-existing helpers for writing
+  TeamCity parameters, at build-type and project scope respectively, differing only in
+  `ConfigurationType` and one word of log text. They are now a single
+  `setParameter(configurationType: ConfigurationType, id: String, name: String, value: String)`,
+  used by every call site including the pre-existing `JDK_VERSION` one. Merging them keeps
+  `resolveJavaHome` (Decision 9) a class member without tripping detekt's `TooManyFunctions`
+  limit.
 
 ## Worked example
 
@@ -135,18 +133,23 @@ Takeaways:
   `--java-home-mapping=env.JDK_{major}_0,...` for the first time doesn't need this design doc
   to understand what gets substituted.
 
-### 7. Major version is derived from `javaVersion`'s trailing segment
+### 7. Major version is derived per the Java version scheme, and may fail to derive
 
-- `javaVersion` values from the registry come in two shapes seen in existing fixtures:
-  dotted legacy form (`"1.8"`) and bare modern form (`"11"`, `"17"`, `"21"`, `"25"`).
-- Both shapes resolve to the same major-version integer used for override lookup and template
-  substitution: take the substring after the last `.`, or the whole string if there is no `.`,
-  then parse as an integer.
-- Examples: `"1.8"` → `8`; `"8"` → `8`; `"11"` → `11`; `"17"` → `17`.
+- Extraction: trim, drop a leading `1.`, take the segment before the next `.`, parse as a
+  positive integer. That is the Java version scheme itself — pre-9 releases put the major in
+  the second segment (`1.8`), everything since puts it first (`21.0.1`).
+- Examples: `"1.8"` → `8`; `"1.8.0_292"` → `8`; `"8"` → `8`; `"17"` → `17`; `"21.0.1"` → `21`.
 - This is why `8` needs no built-in exception (Decision 4) — `"1.8"` and an override keyed
   `8=...` already refer to the same major through this extraction rule; the *naming* exception
   (`env.JDK_1_8` instead of `env.JDK_8_0`) is what still needs an explicit caller-supplied
   override, not the version-matching itself.
+- The registry does not validate `javaVersion` — it is a free-form `String?`, and the registry's
+  own fixtures include `"   "` and `"999999999999999999999"`. So extraction returns `null`
+  rather than raising for anything that yields no positive integer, and `resolveJavaHome` treats
+  that exactly like a null `javaVersion`: fall back to the parent (Decision 9), with a warning
+  naming the offending value. Raising here would abort `createBuildChain` partway, leaving the
+  project, VCS root and compile config already created — a worse outcome than an inherited
+  `env.JAVA_HOME` for a component whose registry entry is malformed anyway.
 
 ### 8. Eager validation of every mapping entry, not lazy failure at `setParameter` time
 
@@ -187,9 +190,8 @@ Takeaways:
 - The removal condition is tracked as
   [`docs/tech-debt/TD-001-jdk-version-param-removal.md`](../../../docs/tech-debt/TD-001-jdk-version-param-removal.md)
   (this repo's first tech-debt record) rather than only here — a `TD-NNN` file survives this
-  change folder being archived, so the removal condition stays discoverable long after
-  OCTOPUS-2473 itself is history. The code points at the same file via a `TD-001:` comment on
-  the `JDK_VERSION`-setting block.
+  change folder being archived, so the removal condition stays discoverable afterwards. The
+  code points at the same file via a `TD-001:` comment on the `JDK_VERSION`-setting block.
 - No specific date — this is consumer-migration-gated, not time-gated.
 
 ## Out of Scope

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -46,12 +46,18 @@ Takeaways:
   "overrides-only" form (see Decision 3).
 - Row 5: a bare entry is a hard failure wherever it isn't in position 0, not a silent fallback
   or reordering (see Decision 2).
+- **Not shown in the table**: if `parentProjectId` had no `env.JAVA_HOME` at all, row 1's result 
+  would be `env.JAVA_HOME = ""` — still explicitly written on the new project, just empty, 
+  never *un*written (see Decision 9).
 
 ## Goals / Non-Goals
 
 **Goals:**
 - Every team using this tool can get a correct `env.JAVA_HOME` reference for their build,
   regardless of what they've named their agent-side JDK parameters.
+- Every component project this tool creates ends up with its own `env.JAVA_HOME` project
+  parameter — present and directly editable in TeamCity, even if its value is empty — rather
+  than one that's silently absent for some projects and present for others.
 - JDK majors not yet known to this tool (e.g. a future 27) work automatically once a team has
   supplied a leading template in `--java-home-mapping`, without a code change here — the
   formula itself is caller data, not a constant in this codebase.
@@ -70,81 +76,47 @@ Takeaways:
 
 ### 1. Override source is a CLI flag, not a TeamCity project parameter
 
-- Considered reading the mapping from a TeamCity project parameter (mirroring how
-  `defaultJDKVersion` is read), which would let teams edit it in the TeamCity UI without
-  touching pipeline scripts.
-- Rejected because the CLI flag was the user's explicit choice: it keeps the mapping visible
-  and versioned next to the pipeline script that invokes this tool, rather than living as
-  server-side state that's easy to forget exists.
+- `--java-home-mapping` lives on the CLI invocation, keeping it visible and versioned next to
+  the pipeline script that calls this tool, rather than as server-side TeamCity state.
 - Lands in `TeamcityCreateBuildChainCommand`'s companion object as
   `JAVA_HOME_MAPPING = "--java-home-mapping"`.
 
 ### 2. Mapping format reuses `SPLIT_SYMBOLS`; overrides are `key=value`, the template is a bare leading entry
 
-- Considered a JSON object string for more structure, but there is no existing
-  JSON-parsing-from-CLI-string precedent anywhere in this repo, so it would be new machinery
-  for a handful of entries.
-- `key=value` pairs split on `SPLIT_SYMBOLS` matches the exact idiom
-  `TeamcityUpdateParameterCommand` already uses for its ID-list options, so a reader of this
-  file already knows the convention for the override entries.
-- The template entry is deliberately *not* another `key=value` pair (e.g. not
-  `default=env.JDK_{major}_0`) — it's a bare value with no key at all, and it must be the
-  first segment in the option value:
-  `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`.
-- A bare entry appearing anywhere other than position 0 (e.g.
-  `--java-home-mapping=8=env.JDK_1_8,env.JDK_{major}_0`) is a validation error, not silently
-  accepted or reordered — position is the only signal that distinguishes "this is the
-  template" from "this is a malformed override missing its key", so the parser must be strict
-  about it rather than guessing intent.
+- Entries are comma/semicolon-separated (`SPLIT_SYMBOLS`), matching
+  `TeamcityUpdateParameterCommand`'s existing ID-list option convention.
+- The template entry is a bare value with no key (not `default=env.JDK_{major}_0`), and it
+  must be the first segment: `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`.
+- A bare entry at any position other than 0 (e.g.
+  `--java-home-mapping=8=env.JDK_1_8,env.JDK_{major}_0`) is a validation error — position is
+  the only signal that distinguishes the template from a malformed override.
 
 ### 3. The leading template is required whenever the option is supplied
 
-- Considered making the template optional (an overrides-only mapping would then just leave
-  every uncovered major to the parent-project fallback).
-- Overridden after review: a caller who bothers to pass `--java-home-mapping` almost certainly
-  wants a real answer for majors they didn't think to list, not a silent, easy-to-miss fallback
-  to whatever the parent project happens to have. Requiring the template up front forces that
-  choice to be explicit at the call site instead of discovered later as an unexpected `%env.JDK_1_8%`
-  inherited from the parent.
-- `--java-home-mapping=8=env.JDK_1_8,11=env.JDK_11_0` (no leading template) is therefore
-  rejected outright, not treated as "overrides only, no formula" — see the spec's mandatory-template
-  requirement.
-- Omitting the whole option is still fine and unaffected by this decision: no flag at all means
-  no mapping, which is the existing parent-project-fallback path (Decision 6).
+- `--java-home-mapping=8=env.JDK_1_8,11=env.JDK_11_0` (no leading template) is rejected
+  outright — there is no "overrides only, no formula" form.
+- Omitting the whole option is unaffected: no flag at all means no mapping, which is the
+  parent-project-fallback path (Decision 9).
 
 ### 4. The fallback formula is caller-supplied data (the leading bare entry), not a constant in this codebase
 
-- An earlier version of this design had `env.JDK_{major}_0` (plus a built-in
-  `8 -> env.JDK_1_8` exception) hardcoded in `JavaHomeMapping`, applied whenever an explicit
-  override was missing.
-- Overridden after review: the whole point of making the mapping overridable is that no naming
-  scheme this tool bakes in is guaranteed to hold for every team or every future JDK release —
-  a hardcoded formula is exactly the same class of problem as a hardcoded map, just one level
-  more abstract.
-- Instead, `--java-home-mapping` requires the leading bare entry (Decision 3) whose value is a
-  template containing the placeholder `{major}` (e.g. `env.JDK_{major}_0`), substituted at
-  resolution time.
-- There is now no formula and no built-in exception anywhere in the code — a team that wants
-  the `8 -> env.JDK_1_8` behavior supplies it as an explicit override alongside their own
-  template, exactly like any other override.
-- If resolution has nothing to go on for a given major (this only happens when the whole
-  option was omitted — see Decision 3), it falls through to the parent-project fallback
-  (Decision 6) rather than guessing.
+- `--java-home-mapping` requires the leading bare entry (Decision 3), whose value is a template
+  containing the placeholder `{major}` (e.g. `env.JDK_{major}_0`), substituted at resolution
+  time.
+- There is no formula and no built-in exception anywhere in the code — a team that wants an
+  `8 -> env.JDK_1_8` mapping supplies it as an explicit override alongside their own template,
+  exactly like any other override.
+- If resolution has nothing to go on for a given major (only possible when the whole option
+  was omitted — Decision 3), it falls through to the parent-project fallback (Decision 9).
 
 ### 5. Override/template values are not required to look like `env.<NAME>`
 
-- An earlier version of this design required every value (override and template) to match
-  `^env\.[A-Za-z0-9_]+$`, rejecting anything not literally prefixed `env.`.
-- Overridden after review: this tool has no way to verify a value actually corresponds to a
-  real TeamCity agent parameter regardless of prefix, so a prefix check only catches one
-  specific typo shape while rejecting otherwise-valid names a team might already be using for
-  a different kind of parameter. Requiring `env.` added a rule this tool can't meaningfully
-  enforce.
-- What's still validated, because these are structural mistakes this tool *can* detect with
+- No entry is required to start with `env.` or any other fixed prefix — this tool can't verify
+  a value corresponds to a real TeamCity agent parameter regardless of prefix.
+- What's validated instead, because these are structural mistakes this tool *can* detect with
   certainty:
   - a value must be non-blank;
-  - an override value must not already be `%`-wrapped (a caller who writes `8=%env.JDK_1_8%`
-    almost certainly means `8=env.JDK_1_8` — this tool wraps the value itself);
+  - an override value must not already be `%`-wrapped (this tool wraps the value itself);
   - an override value must not contain the `{major}` placeholder (only the template
     substitutes it);
   - the template must contain **exactly one** `{major}` occurrence.
@@ -163,14 +135,14 @@ Takeaways:
 
 - `javaVersion` values from the registry come in two shapes seen in existing fixtures:
   dotted legacy form (`"1.8"`) and bare modern form (`"11"`, `"17"`, `"21"`, `"25"`).
-- Both shapes SHALL resolve to the same major-version integer used for override lookup and
-  template substitution: take the substring after the last `.`, or the whole string if there
-  is no `.`, then parse as an integer.
+- Both shapes resolve to the same major-version integer used for override lookup and template
+  substitution: take the substring after the last `.`, or the whole string if there is no `.`,
+  then parse as an integer.
 - Examples: `"1.8"` → `8`; `"8"` → `8`; `"11"` → `11`; `"17"` → `17`.
-- This is why `8` needs no built-in exception (Decision 4) — `"1.8"` and a hypothetical
-  override keyed `8=...` already refer to the same major through this extraction rule; the
-  *naming* exception (`env.JDK_1_8` instead of `env.JDK_8_0`) is what still needs an explicit
-  caller-supplied override, not the version-matching itself.
+- This is why `8` needs no built-in exception (Decision 4) — `"1.8"` and an override keyed
+  `8=...` already refer to the same major through this extraction rule; the *naming* exception
+  (`env.JDK_1_8` instead of `env.JDK_8_0`) is what still needs an explicit caller-supplied
+  override, not the version-matching itself.
 
 ### 8. Eager validation of every mapping entry, not lazy failure at `setParameter` time
 
@@ -178,45 +150,34 @@ Takeaways:
   other than position 0, a non-numeric override key, an already-`%`-wrapped value, a value
   containing `{major}` where it shouldn't, a template missing (or containing more than one)
   `{major}` placeholder, or a duplicate override key — is rejected at option-parse time with a
-  message naming the specific bad entry.
-- Rejected the alternative of accepting anything and letting a bad reference silently write
-  garbage into TeamCity (e.g. `%%env.JDK_1_8%%` or an unresolvable parameter) — that failure
-  mode would only surface much later, as a broken build, far from the CLI invocation that
-  caused it.
+  message naming the specific bad entry, before any TeamCity project is created.
 
-### 9. Fallback to the parent project's existing `env.JAVA_HOME`, not "skip"
+### 9. `env.JAVA_HOME` is always written: mapping resolution, else the parent's value, else an empty string
 
-- An earlier version of this design had the feature skip entirely (no `env.JAVA_HOME` written)
-  whenever the flag was absent or the component had no `javaVersion`, making it strictly
-  opt-in with zero behavior change for anyone not using the flag.
-- Overridden after review: skipping meant a team that already has `env.JAVA_HOME` configured
-  at the parent-project level (their existing convention, predating this tool) would see it
-  silently absent on every new child project this tool creates, forcing manual re-entry per
-  component.
-- Falling back to `client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")` — the exact
-  same lookup pattern `JDK_VERSION`'s default already uses — means an already-working
-  parent-level setup keeps working with zero flag usage, at the cost of the sharp edge
-  documented in the worked example above (parent value wins over the component's actual
-  `javaVersion` when the option is omitted). This trade-off is accepted; see Risks below.
+- `setProjectParameter(project.id, "env.JAVA_HOME", ...)` is called exactly once per
+  `createBuildChain` run, with no guard. The value is, in order: the mapping's resolution
+  (Decision 4), the parent's existing `env.JAVA_HOME`
+  (`client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")` — the same lookup pattern
+  `JDK_VERSION`'s default already uses), or `""`.
+- Scope: every project this tool creates ends up with the `env.JAVA_HOME` parameter present,
+  ready to be filled in directly in TeamCity if nothing else supplied a value. See Risks below
+  for the trade-off this implies for an already-working parent-level setup.
 
-### 10. Written at project level, not build-type level
+### 10. Written at project level, not build-type level, and unconditionally
 
-- `JDK_VERSION` is only ever set on the compile build-type (`compileConfig.id`).
-  `env.JAVA_HOME` is instead set on the newly created component project (`project.id`) via
-  `setProjectParameter`, so it's inherited by every build config under that project (compile,
-  RC, checklist, release) — not just the compile step, since release/RC builds can also need a
-  JDK on the agent.
-- This is a deliberate behavioral difference from `JDK_VERSION`'s narrower scope, not an
-  inconsistency.
+- `JDK_VERSION` is only ever set on the compile build-type (`compileConfig.id`), and only when
+  it differs from the project default. `env.JAVA_HOME` is instead set on the newly created
+  component project (`project.id`) via `setProjectParameter`, so it's inherited by every build
+  config under that project (compile, RC, checklist, release) — not just the compile step,
+  since release/RC builds can also need a JDK on the agent.
+- Unlike `JDK_VERSION`'s conditional write, `env.JAVA_HOME` is written every time, with no
+  "only if different" or "only if non-empty" guard (Decision 9).
 
 ### 11. `JDK_VERSION` is deprecated but not removed in this change
 
 - Both parameters are set side by side.
-- This repo has no existing tech-debt-tracking convention of its own (unlike `octopus-base`'s
-  single-table register or
-  `octopus-components-management-portal-wt/rms-registered-build-params`'s per-item files);
-  rather than inventing one, the removal condition is recorded here as a decision so a future
-  change can find it:
+- This repo has no existing tech-debt-tracking convention of its own; the removal condition is
+  recorded here so a future change can find it:
   - **Remove the `JDK_VERSION`-setting block once all teams currently depending on it have
     migrated their build templates to consume `%env.JAVA_HOME%` instead of the literal
     `%JDK_VERSION%` value.**
@@ -233,11 +194,12 @@ Takeaways:
 
 ## Risks / Trade-offs
 
-- **Silent overwrite of an existing `env.JAVA_HOME`.**
+- **Silent overwrite of an existing `env.JAVA_HOME`, possibly with an empty string.**
   - If a team already hand-configured `env.JAVA_HOME` on a component's project directly (not
     on the parent), the next `create-build-chain` run without `--java-home-mapping` for that
-    component will read the *parent's* value (or nothing) and overwrite the child project's
-    existing value.
+    component will read the *parent's* value (or fall through to `""`) and overwrite the
+    child project's existing value — including blanking it out entirely if the parent has
+    nothing configured either.
   - Accepted because `setProjectParameter` always writes at project-creation time for a
     project this tool itself just created — there's no established prior art of a human
     hand-editing a freshly-created child project's parameters before this tool finishes, so

--- a/openspec/changes/set-env-java-home-from-java-version/design.md
+++ b/openspec/changes/set-env-java-home-from-java-version/design.md
@@ -164,6 +164,9 @@ Takeaways:
   resolution wrapped as `%...%` (Decision 4), the parent's existing `env.JAVA_HOME`
   (`client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")` — the same lookup pattern
   `JDK_VERSION`'s default already uses, used as-is, not re-wrapped), or `""`.
+- `client.getParameter` throws `FeignException.NotFound` rather than returning `null` when a
+  parameter doesn't exist on a project. No project has `env.JAVA_HOME` until a team sets one, so
+  the parent-fallback lookup catches `FeignException.NotFound` and treats it as an empty value.
 - Scope: every project this tool creates ends up with the `env.JAVA_HOME` parameter present,
   ready to be filled in directly in TeamCity if nothing else supplied a value. See Risks below
   for the trade-off this implies for an already-working parent-level setup.

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -82,8 +82,9 @@ component has no `javaVersion`:**
 
 - `TeamcityCreateBuildChainCommand`
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
-  new CLI option, new resolution/fallback logic, one new project-level `setProjectParameter`
-  call.
+  new CLI option, a new private `resolveJavaHome` member, and one new project-level
+  `setParameter` call (the pre-existing `setBuildTypeParameter`/`setProjectParameter` helpers
+  were merged into a single `setParameter` during implementation — see `design.md` Context).
 - New pure mapping/parsing logic, `JavaHomeMapping` and `JavaHomeMappingOption`, in their own
   `org.octopusden.octopus.automation.teamcity.utils.javahome` subpackage
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/`). Their tests

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -83,8 +83,13 @@ component has no `javaVersion`:**
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
   new CLI option, new resolution/fallback logic, one new project-level `setProjectParameter`
   call.
-- A new small pure mapping helper (`JavaHomeMapping` or similar) — no existing file owns this
-  logic today.
+- New pure mapping/parsing logic, `JavaHomeMapping` and `JavaHomeMappingOption`, in their own
+  `org.octopusden.octopus.automation.teamcity.utils.javahome` subpackage
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/`). Their tests
+  live under `src/test/kotlin/utils/javahome/` in the shorter `utils.javahome` package (this
+  repo's existing test file, `ApplicationTest.kt`, uses no package at all, so there was no
+  established test-package convention to match) — no existing file or package owned this logic
+  before this change.
 - **Behavior change for existing consumers**: any TeamCity project under this tool's
   management that already has its *own* `env.JAVA_HOME` project parameter set will have it
   silently overwritten — with the parent-project fallback value, or with an empty string if

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 - `TeamcityCreateBuildChainCommand` sets a `JDK_VERSION` build-type parameter from the

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -73,9 +73,10 @@ component has no `javaVersion`:**
 **`JDK_VERSION` is marked deprecated, not removed:**
 - both parameters get set side by side during a migration period so nothing currently reading
   `JDK_VERSION` breaks;
-- the deprecation is recorded as a numbered decision in `design.md` (this repo has no existing
-  tech-debt tracking of its own) rather than as a scattered code comment, so there's one place
-  a future cleanup pass can find the removal condition.
+- the removal condition is tracked as `docs/tech-debt/TD-001-jdk-version-param-removal.md`
+  (this repo's first tech-debt record, one file per item), referenced from a short `TD-001:`
+  comment on the `JDK_VERSION`-setting block — not just a decision noted in `design.md`, since
+  this change folder eventually gets archived and the tech-debt file needs to outlive it.
 
 ## Affected areas
 

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -1,0 +1,114 @@
+## Why
+
+- `TeamcityCreateBuildChainCommand` sets a `JDK_VERSION` build-type parameter from the
+  component-registry's `javaVersion` field (e.g. `"1.8"`, `"11"`). That's a bare version
+  string — it only does anything useful if a build template downstream separately knows how
+  to turn `"1.8"` into an actual JDK install path.
+- TeamCity's own convention is different: agents publish `env.JDK_1_8`, `env.JDK_17_0`,
+  `env.JDK_21_0`, `env.JDK_25_0`, ... as configuration parameters pointing at real JDK
+  installs, and a build selects one by setting `env.JAVA_HOME` to a *reference*, e.g.
+  `%env.JDK_17_0%`. Teams that already rely on that convention get nothing from `JDK_VERSION`
+  today and have to hand-configure `env.JAVA_HOME` per project themselves.
+- This CLI is invoked from many different teams' TeamCity pipelines, and those teams don't all
+  name their agent-side JDK parameters the same way — nor is the naming scheme guaranteed to
+  survive the next JDK release (a hypothetical JDK 27 might not fit the `env.JDK_{major}_0`
+  pattern some team already committed to).
+- Any fixed mapping *or* fixed formula baked into this tool will eventually be wrong for
+  someone, so both the per-version overrides *and* the fallback formula itself need to be
+  supplied by the caller, not hardcoded here.
+
+## What Changes
+
+Resolve and set `env.JAVA_HOME` at project creation time, alongside the existing `JDK_VERSION`
+logic (which is not removed — see the deprecation note below).
+
+**A new `--java-home-mapping` CLI option on `create-build-chain`:**
+- Accepts comma/semicolon-separated entries (`SPLIT_SYMBOLS` convention already used by
+  `TeamcityUpdateParameterCommand`).
+- Two kinds of entry, both in the same option value:
+  - a **required leading template**: a *bare* value (no `key=`), always the first segment,
+    containing the placeholder `{major}`, e.g. `env.JDK_{major}_0`. There is no template baked
+    into this tool — if `--java-home-mapping` is supplied at all, the caller must supply the
+    formula fallback themselves, first, in this option;
+  - **explicit per-major overrides**: every other segment, a `key=value` pair where the key is
+    a positive integer and the value is the parameter name to use for that major, e.g.
+    `8=env.JDK_1_8`.
+- Example: `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`.
+- Validated eagerly at parse time:
+  - the option, if supplied, must start with the bare template — an overrides-only value
+    (no leading template) is rejected, not treated as "no formula, overrides only";
+  - a bare entry anywhere other than position 0 is rejected;
+  - the template must contain exactly one `{major}` placeholder;
+  - an override key must be a positive integer, and no override key may repeat;
+  - an override value must not already be `%`-wrapped and must not contain `{major}`;
+  - neither overrides nor the template are required to start with `env.` — this tool can't
+    verify a value corresponds to a real agent parameter regardless of prefix, so only
+    structural mistakes (see above) are checked.
+  - Invalid input fails the command immediately with a message naming the bad entry.
+- The component's major version is derived from `javaVersion` by taking the segment after the
+  last `.` (`"1.8"` → `8`, `"17"` → `17`), so both the legacy dotted form and the bare modern
+  form resolve consistently.
+
+**Resolution, when the component has a non-null `javaVersion` and the option was supplied:**
+1. explicit override for that major, if present;
+2. otherwise the leading template with `{major}` substituted.
+
+**Fallback to the parent project, when `--java-home-mapping` is omitted entirely, or the
+component has no `javaVersion`:**
+- the command does **not** skip setting `env.JAVA_HOME` — it falls back to whatever
+  `env.JAVA_HOME` is already configured on `parentProjectId`, read the same way the existing
+  `JDK_VERSION` default is read today;
+- if that's also unset, nothing is written.
+
+**Where it's written:**
+- as a **project-level** parameter on the newly created component project (`project.id`), not
+  only on the compile build-type;
+- every build config created under that project (compile, RC, checklist, release) inherits it
+  through normal TeamCity parameter inheritance, unlike `JDK_VERSION`, which today only ever
+  overrides the compile step.
+
+**`JDK_VERSION` is marked deprecated, not removed:**
+- both parameters get set side by side during a migration period so nothing currently reading
+  `JDK_VERSION` breaks;
+- the deprecation is recorded as a numbered decision in `design.md` (this repo has no existing
+  tech-debt tracking of its own) rather than as a scattered code comment, so there's one place
+  a future cleanup pass can find the removal condition.
+
+## Affected areas
+
+- `TeamcityCreateBuildChainCommand`
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
+  new CLI option, new resolution/fallback logic, one new project-level `setProjectParameter`
+  call.
+- A new small pure mapping helper (`JavaHomeMapping` or similar) — no existing file owns this
+  logic today.
+- **Behavior change for existing consumers**: any TeamCity project under this tool's
+  management that already has its *own* `env.JAVA_HOME` project parameter set will have it
+  silently overwritten by the parent-project fallback value the next time
+  `create-build-chain` runs without `--java-home-mapping` for that component. Teams relying on
+  a manually-set `env.JAVA_HOME` should set it on the *parent* project instead, or start
+  passing `--java-home-mapping`, before this ships.
+- No change to `JDK_VERSION` behavior itself — it keeps being set exactly as before.
+
+## Out of scope
+
+- Removing or ceasing to set `JDK_VERSION` — tracked as a future decision once teams have
+  migrated their build templates to consume `env.JAVA_HOME`; not part of this change.
+- A TeamCity-project-parameter-based override source (as opposed to the CLI flag) —
+  considered and rejected in favor of the CLI flag; see `design.md`.
+- Validating that a mapping value corresponds to an agent parameter that actually exists on
+  any real TeamCity agent — this tool has no visibility into agent configuration.
+- Requiring a specific naming prefix (e.g. `env.`) on mapping values — this tool can't verify
+  it means anything real anyway; see `design.md` Decision 5.
+- Applying the same treatment to any parameter other than `env.JAVA_HOME` (e.g. no generic
+  "arbitrary parameter mapping" mechanism is introduced).
+- Any hardcoded major-version-to-parameter-name mapping or formula living in this tool's
+  code — by design, everything (including the fallback formula) is caller-supplied data now.
+
+## Rollout note
+
+`--java-home-mapping` is optional and additive: omitting it preserves current behavior for
+`JDK_VERSION` and only changes `env.JAVA_HOME` behavior if a value is already present on the
+parent project (see the behavior-change note above). Teams adopt the mapping at their own pace
+by adding the flag, with its required leading template, to their pipeline's
+`create-build-chain` invocation.

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -45,16 +45,17 @@ logic (which is not removed — see the deprecation note below).
     verify a value corresponds to a real agent parameter regardless of prefix, so only
     structural mistakes (see above) are checked.
   - Invalid input fails the command immediately with a message naming the bad entry.
-- The component's major version is derived from `javaVersion` by taking the segment after the
-  last `.` (`"1.8"` → `8`, `"17"` → `17`), so both the legacy dotted form and the bare modern
-  form resolve consistently.
+- The component's major version is derived from `javaVersion` per the Java version scheme —
+  drop a leading `1.`, take the segment before the next `.` (`"1.8"` → `8`, `"17"` → `17`,
+  `"21.0.1"` → `21`). The registry does not constrain that field, so a value yielding no
+  positive integer derives no major and falls back to the parent project rather than raising.
 
 **Resolution, when the component has a non-null `javaVersion` and the option was supplied:**
 1. explicit override for that major, if present;
 2. otherwise the leading template with `{major}` substituted.
 
 **Fallback to the parent project, when `--java-home-mapping` is omitted entirely, or the
-component has no `javaVersion`:**
+component's `javaVersion` is absent or yields no major version:**
 - the command does **not** skip setting `env.JAVA_HOME` — it falls back to whatever
   `env.JAVA_HOME` is already configured on `parentProjectId`, read the same way the existing
   `JDK_VERSION` default is read today;
@@ -75,23 +76,20 @@ component has no `javaVersion`:**
   `JDK_VERSION` breaks;
 - the removal condition is tracked as `docs/tech-debt/TD-001-jdk-version-param-removal.md`
   (this repo's first tech-debt record, one file per item), referenced from a short `TD-001:`
-  comment on the `JDK_VERSION`-setting block — not just a decision noted in `design.md`, since
-  this change folder eventually gets archived and the tech-debt file needs to outlive it.
+  comment on the `JDK_VERSION`-setting block.
 
 ## Affected areas
 
 - `TeamcityCreateBuildChainCommand`
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
   new CLI option, a new private `resolveJavaHome` member, and one new project-level
-  `setParameter` call (the pre-existing `setBuildTypeParameter`/`setProjectParameter` helpers
-  were merged into a single `setParameter` during implementation — see `design.md` Context).
+  `setParameter` call. The two pre-existing parameter-writing helpers,
+  `setBuildTypeParameter` and `setProjectParameter`, are one `setParameter(configurationType,
+  id, name, value)` — see `design.md` Context.
 - New pure mapping/parsing logic, `JavaHomeMapping` and `JavaHomeMappingOption`, in their own
   `org.octopusden.octopus.automation.teamcity.utils.javahome` subpackage
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/`). Their tests
-  live under `src/test/kotlin/utils/javahome/` in the shorter `utils.javahome` package (this
-  repo's existing test file, `ApplicationTest.kt`, uses no package at all, so there was no
-  established test-package convention to match) — no existing file or package owned this logic
-  before this change.
+  live under `src/test/kotlin/utils/javahome/` in the shorter `utils.javahome` package.
 - **Behavior change for existing consumers**: any TeamCity project under this tool's
   management that already has its *own* `env.JAVA_HOME` project parameter set will have it
   silently overwritten — with the parent-project fallback value, or with an empty string if

--- a/openspec/changes/set-env-java-home-from-java-version/proposal.md
+++ b/openspec/changes/set-env-java-home-from-java-version/proposal.md
@@ -58,11 +58,14 @@ component has no `javaVersion`:**
 - the command does **not** skip setting `env.JAVA_HOME` — it falls back to whatever
   `env.JAVA_HOME` is already configured on `parentProjectId`, read the same way the existing
   `JDK_VERSION` default is read today;
-- if that's also unset, nothing is written.
+- if that's also unset, `env.JAVA_HOME` is still written on the new project, with an **empty
+  value** — every component project this tool creates ends up with its own `env.JAVA_HOME`
+  parameter, ready to be filled in directly in TeamCity, rather than one silently absent
+  depending on what happened to be configured on the parent at creation time.
 
 **Where it's written:**
 - as a **project-level** parameter on the newly created component project (`project.id`), not
-  only on the compile build-type;
+  only on the compile build-type — always written, even when its value is empty;
 - every build config created under that project (compile, RC, checklist, release) inherits it
   through normal TeamCity parameter inheritance, unlike `JDK_VERSION`, which today only ever
   overrides the compile step.
@@ -84,10 +87,10 @@ component has no `javaVersion`:**
   logic today.
 - **Behavior change for existing consumers**: any TeamCity project under this tool's
   management that already has its *own* `env.JAVA_HOME` project parameter set will have it
-  silently overwritten by the parent-project fallback value the next time
-  `create-build-chain` runs without `--java-home-mapping` for that component. Teams relying on
-  a manually-set `env.JAVA_HOME` should set it on the *parent* project instead, or start
-  passing `--java-home-mapping`, before this ships.
+  silently overwritten — with the parent-project fallback value, or with an empty string if
+  the parent has none — the next time `create-build-chain` runs without `--java-home-mapping`
+  for that component. Teams relying on a manually-set `env.JAVA_HOME` should set it on the
+  *parent* project instead, or start passing `--java-home-mapping`, before this ships.
 - No change to `JDK_VERSION` behavior itself — it keeps being set exactly as before.
 
 ## Out of scope
@@ -107,8 +110,9 @@ component has no `javaVersion`:**
 
 ## Rollout note
 
-`--java-home-mapping` is optional and additive: omitting it preserves current behavior for
-`JDK_VERSION` and only changes `env.JAVA_HOME` behavior if a value is already present on the
-parent project (see the behavior-change note above). Teams adopt the mapping at their own pace
-by adding the flag, with its required leading template, to their pipeline's
-`create-build-chain` invocation.
+`--java-home-mapping` is optional and additive for `JDK_VERSION`, which is completely
+unaffected by omitting it. `env.JAVA_HOME`, however, is written on every new component project
+regardless of whether the flag is used — either from the mapping, from the parent project's
+existing value, or as an empty placeholder (see the behavior-change note above). Teams adopt
+the mapping at their own pace by adding the flag, with its required leading template, to their
+pipeline's `create-build-chain` invocation.

--- a/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
@@ -1,0 +1,200 @@
+## Purpose
+
+Governs how `create-build-chain` resolves and writes the `env.JAVA_HOME` TeamCity parameter for
+a newly created component project, based on the component-registry's `javaVersion` and an
+optional caller-supplied mapping of a required leading default template plus per-major
+overrides. Does not govern the existing `JDK_VERSION` parameter, which is unchanged by this
+capability. No major-version-to-parameter-name mapping or formula is built into this tool —
+everything used for resolution is caller-supplied via `--java-home-mapping`.
+
+## ADDED Requirements
+
+### Requirement: `--java-home-mapping`, when supplied, must start with a bare leading template entry
+
+`create-build-chain` SHALL accept an optional `--java-home-mapping` option whose value is one
+or more entries separated by `,` or `;`.
+
+- If the option is supplied, its **first entry SHALL be bare** (no `key=` prefix) — the default
+  template, containing exactly one `{major}` placeholder, e.g. `env.JDK_{major}_0`.
+- An option value consisting only of `key=value` override entries, with no leading bare
+  template, SHALL be rejected.
+- Every entry after the first SHALL be an **override**: a `key=value` pair.
+- A bare entry appearing at any position other than 0 SHALL be rejected.
+
+#### Scenario: valid mapping with a leading template and overrides is accepted
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0` is supplied
+- **THEN** the command proceeds and all entries are available for resolution
+
+#### Scenario: mapping with only overrides, no leading template, is rejected
+
+- **WHEN** `--java-home-mapping=8=env.JDK_1_8,11=env.JDK_11_0` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message noting the
+  leading template entry is required
+
+#### Scenario: a bare entry NOT in the first position is rejected
+
+- **WHEN** `--java-home-mapping=8=env.JDK_1_8,env.JDK_{major}_0` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message noting the
+  bare entry is only valid as the first segment
+
+### Requirement: mapping entries are validated for structural correctness, not for a naming prefix
+
+Each entry SHALL be validated against structural rules only. No entry (override or template)
+SHALL be required to start with `env.` or any other fixed prefix — this tool cannot verify a
+value corresponds to a real TeamCity agent parameter regardless of prefix, so only mistakes
+this tool can detect with certainty are rejected:
+
+- an override key SHALL parse as a positive integer;
+- no override key SHALL repeat within a single option value;
+- an override value SHALL be non-blank, SHALL NOT already be `%`-wrapped, and SHALL NOT contain
+  the `{major}` placeholder;
+- the leading template SHALL be non-blank, SHALL NOT already be `%`-wrapped, and SHALL contain
+  **exactly one** `{major}` occurrence.
+
+#### Scenario: override value without an `env.` prefix is accepted
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=JDK_1_8` is supplied
+- **THEN** the command proceeds; the override for major `8` resolves to `%JDK_1_8%`
+
+#### Scenario: non-numeric override key is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,abc=env.JDK_1_8` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid entry
+
+#### Scenario: already-wrapped override value is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=%env.JDK_1_8%` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid entry
+
+#### Scenario: override value containing a `{major}` placeholder is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_{major}_8` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid entry (placeholders are only valid in the leading template)
+
+#### Scenario: duplicate override key is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  duplicated key
+
+#### Scenario: leading template without a `{major}` placeholder is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_HOME,8=env.JDK_1_8` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid leading entry
+
+#### Scenario: leading template with more than one `{major}` placeholder is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_{major}` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid leading entry
+
+### Requirement: the component's major version is derived from `javaVersion`'s trailing segment
+
+The command SHALL derive a major-version integer from `component.buildParameters.javaVersion`
+by taking the substring after the last `.` (or the whole string if there is no `.`) and parsing
+it as an integer. This derived major SHALL be used for both override lookup and template
+substitution.
+
+#### Scenario: dotted legacy form resolves to its trailing segment
+
+- **WHEN** `javaVersion` is `"1.8"`
+- **THEN** the derived major version is `8`
+
+#### Scenario: bare modern form resolves to itself
+
+- **WHEN** `javaVersion` is `"17"`
+- **THEN** the derived major version is `17`
+
+#### Scenario: an override keyed by the derived major matches regardless of the source form
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8` is supplied and the
+  component's `javaVersion` is `"1.8"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_1_8%` (the override for major `8` matches)
+
+### Requirement: explicit override entry resolves the component's major version
+
+When `--java-home-mapping` is supplied and the component has a non-null `javaVersion`, the
+command SHALL resolve the component's derived major version against the supplied override
+entries first, before considering the leading template.
+
+#### Scenario: mapped major version is used
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
+  component's `javaVersion` is `"11"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_11_0%`
+
+#### Scenario: explicit override wins over the leading template for the same major
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,17=env.JDK_17_CUSTOM` is supplied and the
+  component's `javaVersion` is `"17"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_17_CUSTOM%`, not `%env.JDK_17_0%`
+
+### Requirement: unmapped major version substitutes into the caller-supplied leading template
+
+When the component has a non-null `javaVersion` and the resolved major version has no explicit
+override, the command SHALL substitute the major version into the leading template's `{major}`
+placeholder.
+
+#### Scenario: unmapped major version uses the supplied leading template
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
+  component's `javaVersion` is `"17"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_17_0%`
+
+#### Scenario: a future, previously-unlisted major resolves via the same template without a code change
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
+  component's `javaVersion` is `"27"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_27_0%`
+
+#### Scenario: caller-supplied override reproduces the historical major-8 naming when they choose to
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_1_8` is supplied and the
+  component's `javaVersion` is `"1.8"`
+- **THEN** `env.JAVA_HOME` is resolved to `%env.JDK_1_8%` via the explicit override, not
+  `%env.JDK_8_0%` via the template — this tool does not special-case major 8 on its own; the
+  caller must supply the override if they want it
+
+### Requirement: `--java-home-mapping` omitted, or the component has no `javaVersion`, falls back to the parent project's `env.JAVA_HOME`
+
+When `--java-home-mapping` is not supplied at all, or the component has no `javaVersion`, the
+command SHALL NOT skip setting `env.JAVA_HOME`. Instead it SHALL read the existing
+`env.JAVA_HOME` project parameter from `parentProjectId` and use that value, if present.
+
+#### Scenario: no mapping supplied, parent has a default
+
+- **WHEN** `--java-home-mapping` is not supplied and `parentProjectId` has `env.JAVA_HOME` set
+  to `%env.JDK_1_8%`
+- **THEN** the new component project's `env.JAVA_HOME` is set to `%env.JDK_1_8%`, regardless of
+  the component's own `javaVersion`
+
+#### Scenario: no mapping supplied, parent has no default
+
+- **WHEN** `--java-home-mapping` is not supplied and `parentProjectId` has no `env.JAVA_HOME`
+  set
+- **THEN** no `env.JAVA_HOME` parameter is written for the new component project
+
+#### Scenario: mapping supplied but component has no `javaVersion`
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
+  component's `javaVersion` is null
+- **THEN** the parent-project fallback is used, exactly as when the mapping is absent
+
+### Requirement: resolved `env.JAVA_HOME` is written at project level
+
+The command SHALL write the resolved `env.JAVA_HOME` value as a project-level parameter on the
+newly created component project (not a build-type-level parameter), so it is inherited by every
+build configuration created under that project.
+
+#### Scenario: value inherited by non-compile build configurations
+
+- **WHEN** `env.JAVA_HOME` resolves to `%env.JDK_17_0%` for a component whose build chain
+  includes compile, RC, checklist, and release build configurations
+- **THEN** all four build configurations resolve `env.JAVA_HOME` to `%env.JDK_17_0%` through
+  TeamCity's normal project-to-build-type parameter inheritance, without any build-type-level
+  override being written explicitly

--- a/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
@@ -163,8 +163,8 @@ placeholder.
 ### Requirement: `--java-home-mapping` omitted, or the component has no `javaVersion`, falls back to the parent project's `env.JAVA_HOME`
 
 When `--java-home-mapping` is not supplied at all, or the component has no `javaVersion`, the
-command SHALL NOT skip setting `env.JAVA_HOME`. Instead it SHALL read the existing
-`env.JAVA_HOME` project parameter from `parentProjectId` and use that value, if present.
+command SHALL read the existing `env.JAVA_HOME` project parameter from `parentProjectId` and
+use that value as the value to write (see the next requirement for what "write" always means).
 
 #### Scenario: no mapping supplied, parent has a default
 
@@ -173,23 +173,20 @@ command SHALL NOT skip setting `env.JAVA_HOME`. Instead it SHALL read the existi
 - **THEN** the new component project's `env.JAVA_HOME` is set to `%env.JDK_1_8%`, regardless of
   the component's own `javaVersion`
 
-#### Scenario: no mapping supplied, parent has no default
-
-- **WHEN** `--java-home-mapping` is not supplied and `parentProjectId` has no `env.JAVA_HOME`
-  set
-- **THEN** no `env.JAVA_HOME` parameter is written for the new component project
-
 #### Scenario: mapping supplied but component has no `javaVersion`
 
 - **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
   component's `javaVersion` is null
 - **THEN** the parent-project fallback is used, exactly as when the mapping is absent
 
-### Requirement: resolved `env.JAVA_HOME` is written at project level
+### Requirement: `env.JAVA_HOME` is always written at project level, empty if nothing resolves
 
-The command SHALL write the resolved `env.JAVA_HOME` value as a project-level parameter on the
-newly created component project (not a build-type-level parameter), so it is inherited by every
-build configuration created under that project.
+The command SHALL write `env.JAVA_HOME` as a project-level parameter on the newly created
+component project (not a build-type-level parameter) unconditionally — every component project
+this tool creates SHALL end up with its own `env.JAVA_HOME` parameter present, so it can be
+edited directly in TeamCity. If neither the mapping nor the parent project's `env.JAVA_HOME`
+yields a value, the command SHALL write `env.JAVA_HOME` with an **empty string**, not skip the
+write.
 
 #### Scenario: value inherited by non-compile build configurations
 
@@ -198,3 +195,16 @@ build configuration created under that project.
 - **THEN** all four build configurations resolve `env.JAVA_HOME` to `%env.JDK_17_0%` through
   TeamCity's normal project-to-build-type parameter inheritance, without any build-type-level
   override being written explicitly
+
+#### Scenario: no mapping supplied, parent has no default
+
+- **WHEN** `--java-home-mapping` is not supplied and `parentProjectId` has no `env.JAVA_HOME`
+  set
+- **THEN** `env.JAVA_HOME` is still written for the new component project, with an empty value
+
+#### Scenario: mapping and parent both fail to resolve a value
+
+- **WHEN** `--java-home-mapping` is not supplied, the component's `javaVersion` is null, and
+  `parentProjectId` has no `env.JAVA_HOME` set
+- **THEN** `env.JAVA_HOME` is written for the new component project with an empty value, not
+  omitted

--- a/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
@@ -1,3 +1,5 @@
+# Java home resolution
+
 ## Purpose
 
 Governs how `create-build-chain` resolves and writes the `env.JAVA_HOME` TeamCity parameter for

--- a/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-from-java-version/specs/java-home-resolution/spec.md
@@ -69,6 +69,12 @@ this tool can detect with certainty are rejected:
 - **THEN** the command fails before creating any TeamCity project, with a message naming the
   invalid entry
 
+#### Scenario: blank override value is rejected
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid entry
+
 #### Scenario: override value containing a `{major}` placeholder is rejected
 
 - **WHEN** `--java-home-mapping=env.JDK_{major}_0,8=env.JDK_{major}_8` is supplied
@@ -93,22 +99,31 @@ this tool can detect with certainty are rejected:
 - **THEN** the command fails before creating any TeamCity project, with a message naming the
   invalid leading entry
 
-### Requirement: the component's major version is derived from `javaVersion`'s trailing segment
+### Requirement: the component's major version is derived per the Java version scheme
 
 The command SHALL derive a major-version integer from `component.buildParameters.javaVersion`
-by taking the substring after the last `.` (or the whole string if there is no `.`) and parsing
-it as an integer. This derived major SHALL be used for both override lookup and template
-substitution.
+by trimming it, dropping a leading `1.` (the legacy scheme, where the major is the second
+segment), taking the segment before the next `.`, and parsing that as a positive integer. This
+derived major SHALL be used for both override lookup and template substitution.
 
-#### Scenario: dotted legacy form resolves to its trailing segment
+The registry does not constrain `javaVersion`, so a value SHALL be treated as having no
+derivable major whenever this yields no positive integer — a blank value, a non-numeric one, or
+one that overflows an `Int`. This SHALL NOT raise.
 
-- **WHEN** `javaVersion` is `"1.8"`
+#### Scenario: legacy dotted form resolves to its second segment
+
+- **WHEN** `javaVersion` is `"1.8"` or `"1.8.0_292"`
 - **THEN** the derived major version is `8`
 
-#### Scenario: bare modern form resolves to itself
+#### Scenario: modern form resolves to its leading segment
 
-- **WHEN** `javaVersion` is `"17"`
-- **THEN** the derived major version is `17`
+- **WHEN** `javaVersion` is `"17"` or `"21.0.1"`
+- **THEN** the derived major version is `17` and `21` respectively
+
+#### Scenario: a value with no derivable major yields none
+
+- **WHEN** `javaVersion` is `"   "`, `"<value>"`, `"17-ea"`, or `"999999999999999999999"`
+- **THEN** no major version is derived, and no exception is raised
 
 #### Scenario: an override keyed by the derived major matches regardless of the source form
 
@@ -160,11 +175,13 @@ placeholder.
   `%env.JDK_8_0%` via the template — this tool does not special-case major 8 on its own; the
   caller must supply the override if they want it
 
-### Requirement: `--java-home-mapping` omitted, or the component has no `javaVersion`, falls back to the parent project's `env.JAVA_HOME`
+### Requirement: `--java-home-mapping` omitted, or no major derivable, falls back to the parent project's `env.JAVA_HOME`
 
-When `--java-home-mapping` is not supplied at all, or the component has no `javaVersion`, the
-command SHALL read the existing `env.JAVA_HOME` project parameter from `parentProjectId` and
-use that value as the value to write (see the next requirement for what "write" always means).
+When `--java-home-mapping` is not supplied at all, or the component's `javaVersion` is null or
+has no derivable major, the command SHALL read the existing `env.JAVA_HOME` project parameter
+from `parentProjectId` and use that value as the value to write (see the next requirement for
+what "write" always means). When a mapping was supplied and a non-null `javaVersion` failed to
+yield a major, the command SHALL log a warning naming the offending value.
 
 #### Scenario: no mapping supplied, parent has a default
 
@@ -178,6 +195,13 @@ use that value as the value to write (see the next requirement for what "write" 
 - **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
   component's `javaVersion` is null
 - **THEN** the parent-project fallback is used, exactly as when the mapping is absent
+
+#### Scenario: mapping supplied but the component's `javaVersion` has no derivable major
+
+- **WHEN** `--java-home-mapping=env.JDK_{major}_0,11=env.JDK_11_0` is supplied and the
+  component's `javaVersion` is `"<value>"`
+- **THEN** the parent-project fallback is used, a warning naming `"<value>"` is logged, and the
+  command completes without raising
 
 ### Requirement: `env.JAVA_HOME` is always written at project level, empty if nothing resolves
 

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -1,139 +1,208 @@
 ## 1. Mapping resolution logic (Decisions 4, 7, spec: major-version and override/template requirements)
 
-- [ ] 1.1 Write failing unit tests for `JavaHomeMapping.resolve` (no TeamCity/Docker infra
-      needed; no built-in constants to test since there are none by design — Decision 4):
-  - [ ] 1.1.1 explicit override for the resolved major wins, even when a leading template is
+- [x] 1.1 Write failing unit tests for `JavaHomeMapping.resolve` (no TeamCity/Docker infra
+      needed; no built-in constants to test since there are none by design — Decision 4).
+      `src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt` (package `utils.javahome`),
+      7 tests:
+  - [x] 1.1.1 explicit override for the resolved major wins, even when a leading template is
         also present (e.g. major `17` with both `17=env.JDK_17_CUSTOM` and template
         `env.JDK_{major}_0` present resolves to `env.JDK_17_CUSTOM`)
-  - [ ] 1.1.2 major with no override falls back to the supplied leading template with
+  - [x] 1.1.2 major with no override falls back to the supplied leading template with
         `{major}` substituted (e.g. template `env.JDK_{major}_0`, major `17` → `env.JDK_17_0`)
-  - [ ] 1.1.3 an arbitrary unlisted major (e.g. `27`) resolves via the same supplied template
+  - [x] 1.1.3 an arbitrary unlisted major (e.g. `27`) resolves via the same supplied template
         without any code change
-  - [ ] 1.1.4 caller-supplied `8=env.JDK_1_8` override reproduces the historical major-8 naming
+  - [x] 1.1.4 caller-supplied `8=env.JDK_1_8` override reproduces the historical major-8 naming
         only because the caller supplied it — confirm there is no such behavior when it's
         omitted (major `8` with only template `env.JDK_{major}_0` resolves to `env.JDK_8_0`,
         not `env.JDK_1_8`)
-  - [ ] 1.1.5 major-version extraction (Decision 7, own dedicated tests, not just via the
+  - [x] 1.1.5 major-version extraction (Decision 7, own dedicated tests, not just via the
         cases above):
-    - [ ] 1.1.5.1 `javaVersion = "1.8"` → derived major `8`
-    - [ ] 1.1.5.2 `javaVersion = "8"` → derived major `8`
-    - [ ] 1.1.5.3 `javaVersion = "17"` → derived major `17`
-    - [ ] 1.1.5.4 an override keyed `8` matches both `"1.8"` and `"8"` as the source
+    - [x] 1.1.5.1 `javaVersion = "1.8"` → derived major `8`
+    - [x] 1.1.5.2 `javaVersion = "8"` → derived major `8` (covered together with 1.1.5.1 in
+          `an override keyed by the derived major matches both dotted and bare source forms`)
+    - [x] 1.1.5.3 `javaVersion = "17"` → derived major `17` (covered via 1.1.1/1.1.2's `"17"`
+          fixtures)
+    - [x] 1.1.5.4 an override keyed `8` matches both `"1.8"` and `"8"` as the source
           `javaVersion`
-  - [ ] 1.1.6 override value with no `env.` prefix resolves and is used as-is (no prefix
+  - [x] 1.1.6 override value with no `env.` prefix resolves and is used as-is (no prefix
         requirement — Decision 5)
-- [ ] 1.2 Implement `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
-      as a pure object/function (design.md Context — no existing file owns this logic). No
-      hardcoded formula or exceptions anywhere in this function (Decision 4). Note: `template`
-      is non-nullable here — by the time this function is called, the CLI option layer (task 2)
-      has already guaranteed a template exists whenever a mapping was supplied at all.
-- [ ] 1.3 Confirm tests pass: `./gradlew test --tests "*JavaHomeMapping*"`.
+- [x] 1.2 Implement `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
+      as a pure object
+      (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt`,
+      package `org.octopusden.octopus.automation.teamcity.utils.javahome` — moved there from
+      the top-level `teamcity` package after initial implementation, at the user's request,
+      along with `JavaHomeMappingOption` and both test classes; the tests use the shorter
+      `utils.javahome` package instead of mirroring the full main package).
+      No hardcoded formula or exceptions anywhere in this function (Decision 4). `template` is
+      non-nullable — by the time this function is called, `JavaHomeMappingOption.parse` (task 2)
+      has already guaranteed a template exists whenever a mapping was supplied at all. The
+      `{major}` placeholder constant (`JavaHomeMapping.PLACEHOLDER`) lives here since both
+      `resolve` and `JavaHomeMappingOption.parse`'s validation need it.
+- [x] 1.3 Confirm tests pass: 7/7 green, run via the JUnit Platform Console Launcher against
+      `compileTestKotlin` output (`./gradlew test` requires the docker-compose TeamCity/registry
+      stack for this whole module — not available in this environment — so pure-logic tests were
+      run directly against the compiled classpath instead of through the `test` task; the same
+      tests will run under `./gradlew test` on CI without changes).
 
-## 2. `--java-home-mapping` CLI option: mandatory leading template, positional parsing, structural-only validation (Decisions 2, 3, 5, 6, 8, spec: mapping-parsing requirements)
+## 2. `--java-home-mapping` parsing: mandatory leading template, positional parsing, structural-only validation (Decisions 2, 3, 5, 6, 8, spec: mapping-parsing requirements)
 
-- [ ] 2.1 Write failing tests (process-level, matching the existing `ApplicationTest.kt:647`
-      non-zero-exit style) for:
-  - [ ] 2.1.1 valid mapping with a leading template + overrides
+**Seam changed from tasks.md's original plan, agreed with the user before writing tests**: the
+parsing/validation logic was extracted into a pure `JavaHomeMappingOption.parse(raw: String)`
+function and unit-tested directly, instead of process-level tests spawning the built shadow jar
+(`ApplicationTest.kt:647`-style). This is pure parsing logic (string in, parsed value or
+`BadParameterValue` out) — a direct unit test is faster and doesn't require a jar build, per the
+`implement` skill's guidance to test pure logic at its own seam. The actual clikt `option(...)`
+property on `TeamcityCreateBuildChainCommand` that calls this parser is deferred to task 3,
+since that's where the parsed value is first consumed — task 2 delivers the parser only.
+
+- [x] 2.1 Write failing tests for `JavaHomeMappingOption.parse`
+      (`src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt`, package `utils.javahome`,
+      11 tests — one more than originally scoped, see 2.1.12) for:
+  - [x] 2.1.1 valid mapping with a leading template + overrides
         (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) parses without error
-  - [ ] 2.1.2 mapping with only overrides, no leading template
-        (`8=env.JDK_1_8,11=env.JDK_11_0`) exits non-zero, with a message noting the leading
-        template is required
-  - [ ] 2.1.3 a bare entry NOT in the first position
-        (`8=env.JDK_1_8,env.JDK_{major}_0`) exits non-zero, with a message noting the bare
-        entry is only valid first
-  - [ ] 2.1.4 override value with no `env.` prefix (`env.JDK_{major}_0,8=JDK_1_8`) parses
+  - [x] 2.1.2 mapping with only overrides, no leading template
+        (`8=env.JDK_1_8,11=env.JDK_11_0`) throws `BadParameterValue`, with a message noting the
+        leading template is required
+  - [x] 2.1.3 a bare entry NOT in the first position
+        (`8=env.JDK_1_8,env.JDK_{major}_0`) throws `BadParameterValue`, with a message noting
+        the bare entry is only valid first
+  - [x] 2.1.4 override value with no `env.` prefix (`env.JDK_{major}_0,8=JDK_1_8`) parses
         without error (Decision 5 — no prefix requirement)
-  - [ ] 2.1.5 non-numeric override key (`env.JDK_{major}_0,abc=env.JDK_1_8`) exits non-zero
-        with a message naming the bad entry
-  - [ ] 2.1.6 already-`%`-wrapped override value (`env.JDK_{major}_0,8=%env.JDK_1_8%`) exits
-        non-zero
-  - [ ] 2.1.7 override value containing a `{major}` placeholder
-        (`env.JDK_{major}_0,8=env.JDK_{major}_8`) exits non-zero (placeholders only valid in
-        the leading template)
-  - [ ] 2.1.8 duplicate override key (`env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0`) exits
-        non-zero
-  - [ ] 2.1.9 leading template missing the `{major}` placeholder (`env.JDK_HOME,8=env.JDK_1_8`)
-        exits non-zero
-  - [ ] 2.1.10 leading template with more than one `{major}` placeholder
-        (`env.JDK_{major}_{major}`) exits non-zero
-  - [ ] 2.1.11 option omitted entirely: command proceeds, mapping is absent (not "empty
-        mapping with no template" — the whole option is unset)
-- [ ] 2.2 Implement, as separate units:
-  - [ ] 2.2.1 `TeamcityCreateBuildChainCommand.kt` companion object — add
-        `JAVA_HOME_MAPPING = "--java-home-mapping"`, the placeholder token constant
-        (`PLACEHOLDER = "{major}"`), and the two validation regexes (template requiring
-        exactly one placeholder occurrence; override rejecting `%`-wrap and the placeholder —
-        no `env.`-prefix regex, per Decision 5)
-  - [ ] 2.2.2 `TeamcityCreateBuildChainCommand.kt` — add the option property parsing into a
-        small holder (e.g. `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`,
-        itself nullable/absent when the option isn't supplied): split on `SPLIT_SYMBOLS`
-        preserving order; require the first segment to be bare and validate it as the
-        template; validate every remaining segment contains `=` and parses as a numeric
-        override, rejecting any later bare segment; reject duplicate override keys; fail with
-        a message naming the offending entry on any violation
-- [ ] 2.3 Confirm tests pass: `./gradlew test --tests "*ApplicationTest*JavaHomeMapping*"` (or
-      the equivalent method names once written).
+  - [x] 2.1.5 non-numeric override key (`env.JDK_{major}_0,abc=env.JDK_1_8`) throws
+        `BadParameterValue` naming the bad entry
+  - [x] 2.1.6 already-`%`-wrapped override value (`env.JDK_{major}_0,8=%env.JDK_1_8%`) throws
+        `BadParameterValue`
+  - [x] 2.1.7 override value containing a `{major}` placeholder
+        (`env.JDK_{major}_0,8=env.JDK_{major}_8`) throws `BadParameterValue` (placeholders only
+        valid in the leading template)
+  - [x] 2.1.8 duplicate override key (`env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0`) throws
+        `BadParameterValue`
+  - [x] 2.1.9 leading template missing the `{major}` placeholder (`env.JDK_HOME,8=env.JDK_1_8`)
+        throws `BadParameterValue`
+  - [x] 2.1.10 leading template with more than one `{major}` placeholder
+        (`env.JDK_{major}_{major}`) throws `BadParameterValue`
+  - [x] 2.1.11 option omitted entirely: N/A at this seam — `parse` is only ever called with a
+        raw string once clikt has already determined the option was supplied; "option omitted"
+        is a task-3 concern (the clikt property returning `null`/absent), not something
+        `parse` itself can observe.
+  - [x] 2.1.12 (added on review) already-`%`-wrapped **leading template**
+        (`%env.JDK_{major}_0%,8=env.JDK_1_8`) throws `BadParameterValue` — spec's
+        structural-validation requirement lists this for the template too (not just override
+        values), and the original task list only enumerated it for overrides.
+- [x] 2.2 Implement, as separate units:
+  - [x] 2.2.1 `JavaHomeMappingOption.kt` companion object — `OPTION_NAME = "--java-home-mapping"`
+        (moved here from the originally-planned `TeamcityCreateBuildChainCommand` companion
+        object, since that command isn't touched until task 3) and the placeholder constant
+        `JavaHomeMapping.PLACEHOLDER = "{major}"` (task 1). No standalone regexes — validation
+        is inline string checks (`startsWith('%') && endsWith('%')`, placeholder-count-via-split)
+        rather than `Regex`, since each check is a single simple predicate.
+  - [x] 2.2.2 `JavaHomeMappingOption.kt` — `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`
+        with `companion object { fun parse(raw: String): JavaHomeMappingOption }`: splits on
+        `SPLIT_SYMBOLS` preserving order; requires the first segment to be bare and validates it
+        as the template (non-`%`-wrapped, exactly one placeholder); validates every remaining
+        segment contains `=` and parses as a numeric override (non-`%`-wrapped, no placeholder,
+        no duplicate key), rejecting any later bare segment; fails via a private `fail(message)`
+        helper naming the offending entry on any violation. Refactored into `parseTemplate` /
+        `parseOverride` / `isWrapped` / `fail` helper functions to keep `parse` under detekt's
+        `ThrowsCount` limit and each line under the configured max length.
+- [x] 2.3 Confirm tests pass: 11/11 green (18/18 total across both test files), same
+      console-launcher approach as 1.3. `./gradlew detekt ktlintCheck` also green against the
+      new files (`./gradlew clean compileKotlin compileTestKotlin` also verified clean).
 
 ## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9-10, spec: parent-fallback and always-written-at-project-level requirements)
 
-- [ ] 3.1 Write failing functional tests in `ApplicationTest.kt` (extends
+- [x] 3.1 Write failing functional tests in `ApplicationTest.kt` (extended
       `executeForCreateBuildChainCommand` with an optional `javaHomeMapping: String? = null`
-      param, reusing `default-jdk-component` / `custom-jdk-component` fixtures from
-      `TestComponents.groovy:130-154`):
-  - [ ] 3.1.1 no mapping supplied, `TEST_PROJECT` (parent) has no `env.JAVA_HOME` → new
-        project's `env.JAVA_HOME` is written with an **empty string**, not left unset
-  - [ ] 3.1.2 no mapping supplied, `TEST_PROJECT` has `env.JAVA_HOME` pre-set → new project's
+      param, appended to the arg list only when non-null; new test
+      `testTeamCityCreateBuildChainForJavaHome`, reusing `default-jdk-component` /
+      `custom-jdk-component` fixtures from `TestComponents.groovy:130-156`):
+  - [x] 3.1.1 no mapping supplied, `TEST_PROJECT` (parent) has no `env.JAVA_HOME` → new
+        project's `env.JAVA_HOME` is written with an **empty string**, not left unset; also
+        asserted on the RC/checklist/release build configs (combines with 3.1.5 in one round)
+  - [x] 3.1.2 no mapping supplied, `TEST_PROJECT` has `env.JAVA_HOME` pre-set → new project's
         `env.JAVA_HOME` equals the parent's value, for both the 1.8 and 11 fixtures alike
-  - [ ] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
+  - [x] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
         majors (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) → new project's
-        `env.JAVA_HOME` is `%env.JDK_1_8%` for `default-jdk-component` and `%env.JDK_11_0%` for
+        `env.JAVA_HOME` is `""` for `default-jdk-component` (no `javaVersion` at all — falls
+        back to the unset parent, not the mapping) and `%env.JDK_11_0%` for
         `custom-jdk-component`
-  - [ ] 3.1.4 mapping supplied where the leading template (not an override) applies because no
-        override covers the component's major → template applies (needs a fixture with an
-        uncovered `javaVersion`, e.g. `"25"`, or reuse an existing one with overrides that
-        exclude it)
-  - [ ] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
-        (asserts the project-level write, not a build-type-level one)
-  - [ ] 3.1.6 no mapping supplied, component has no `javaVersion`, and `TEST_PROJECT` has no
-        `env.JAVA_HOME` either → new project's `env.JAVA_HOME` is still written, empty (both
-        fallbacks exhausted, still not omitted)
-- [ ] 3.2 Implement, as separate units:
-  - [ ] 3.2.1 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — add the resolution block
-        directly after the existing `JDK_VERSION` block: when the option was supplied and
-        `javaVersion` is present, `JavaHomeMapping.resolve(...)`; otherwise
-        `client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")`
-  - [ ] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — call
-        `setProjectParameter(project.id, "env.JAVA_HOME", resolved ?: "")` **unconditionally,
-        with no guard** — every `createBuildChain` run writes this parameter exactly once,
-        even when `resolved` is null/blank (Decision 9)
-- [ ] 3.3 Confirm tests pass. Functional suite needs the Docker/OKD TeamCity test instance per
-      this workspace's `build-verification` skill — record here whether it was run locally or
-      deferred to CI.
+  - [x] 3.1.4 mapping supplied where the leading template (not an override) applies because no
+        override covers the component's major → reused `custom-jdk-component` (`javaVersion
+        = "11"`) against a mapping with only an `8=` override, confirming `%env.JDK_11_0%` via
+        the template rather than adding a new fixture
+  - [x] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
+        (asserts the project-level write, not a build-type-level one) — covered in 3.1.1's round
+  - [x] 3.1.6 (dropped as a separate case — identical setup to 3.1.1, since
+        `default-jdk-component` already has no `javaVersion`; not duplicated)
+- [x] 3.2 Implement, as separate units:
+  - [x] 3.2.1 `TeamcityCreateBuildChainCommand.kt` — added `javaHomeMapping` option
+        (`.convert { JavaHomeMappingOption.parse(it) }`, no `.required()`/`.default()` so it's
+        `null` when the flag is absent) and the `JAVA_HOME_MAPPING` companion constant
+  - [x] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — calls
+        `setProjectParameter(project.id, "env.JAVA_HOME", resolveJavaHome(...))`
+        unconditionally, right after the (now commented, Decision 11) `JDK_VERSION` block.
+        `resolveJavaHome` is a **top-level private function in the same file** (not a class
+        member) — `javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" } ?: client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME") ?: ""`.
+        (found on review) wrapping (`"%$it%"`) is applied only to the mapping-resolved case —
+        the parent-fallback value is used as-is, since it's already whatever was previously
+        stored (possibly already wrapped, possibly not; this tool doesn't touch it)
+  - [x] 3.2.2a (added on review) `JavaHomeMappingOption.resolveOrNull(javaVersion: String?): String?`
+        added on `JavaHomeMappingOption` itself (not a private helper on the command class) —
+        `TeamcityCreateBuildChainCommand` was already at detekt's `TooManyFunctions` limit (11),
+        and a private member helper for the resolution branch also tripped
+        `CyclomaticComplexMethod` on `createBuildChain`. Moving the branch onto the data class
+        that already owns `overrides`/`template` fixed both without inflating either limit, and
+        reads more naturally: "ask the parsed option to resolve this javaVersion." Two new unit
+        tests added in `JavaHomeMappingOptionTest.kt`.
+- [x] 3.3 Compiled clean (`./gradlew clean compileKotlin compileTestKotlin`) and
+      `./gradlew detekt ktlintCheck` clean. The functional test itself was **not run locally** —
+      this environment has no running Docker daemon (Colima) and starting one wasn't attempted
+      without being asked, per this workspace's guidance on invasive/resource-heavy actions; per
+      the `build-verification` skill, this Docker/OKD-backed suite belongs on CI, not local
+      pre-commit. It will run there on `./gradlew test`.
 
 ## 4. `JDK_VERSION` deprecation note (Decision 11)
 
-- [ ] 4.1 Add a short comment on the existing `JDK_VERSION`-setting block in
-      `TeamcityCreateBuildChainCommand.kt` pointing at `design.md`'s Decision 11 for the
-      removal condition (consumer migration to `env.JAVA_HOME`, not a fixed date). No
-      standalone tech-debt file — this repo has no existing tech-debt-tracking convention, and
-      the decision log in `design.md` is the record per the `openspec` skill's guidance not to
-      duplicate it with a bespoke doc.
-- [ ] 4.2 No behavior or test change here — `JDK_VERSION` continues exactly as today.
+- [x] 4.1 Added a short comment directly above the `JDK_VERSION`-setting block in
+      `TeamcityCreateBuildChainCommand.kt`: "Superseded by env.JAVA_HOME below; kept for teams
+      that still consume it. Remove once every consumer has migrated to %env.JAVA_HOME%
+      (design.md Decision 11)." No standalone tech-debt file — this repo has no existing
+      tech-debt-tracking convention, and the decision log in `design.md` is the record per the
+      `openspec` skill's guidance not to duplicate it with a bespoke doc.
+- [x] 4.2 No behavior or test change — `JDK_VERSION` continues exactly as today (diff-checked:
+      only the comment was added above the existing block, the block's own lines are untouched).
 
 ## 5. Finalization
 
-- [ ] 5.1 Full suite green: `./gradlew build`.
-- [ ] 5.2 Static analysis clean (whatever this repo runs as part of `./gradlew build` —
-      confirm no new lint/detekt findings from the new files).
-- [ ] 5.3 Re-confirm every `Out of scope` item in `proposal.md` actually holds:
-  - `JDK_VERSION` setting logic untouched (diff-check);
-  - no TeamCity-project-parameter-based override path added;
+- [ ] 5.1 Full suite green: `./gradlew build` — **not run**. This environment has no running
+      Docker daemon (Colima), and `./gradlew build` pulls in the docker-compose-backed
+      functional `test` task unconditionally for this module (there's no separate unit-test
+      task). What was verified locally instead: `./gradlew clean compileKotlin
+      compileTestKotlin` (clean) and the pure-logic suite (20/20 green, run via the JUnit
+      Platform Console Launcher against the compiled classpath — see tasks 1.3/2.3). The
+      Docker-backed functional suite, including the new `testTeamCityCreateBuildChainForJavaHome`,
+      needs to run on CI per the `build-verification` skill.
+- [x] 5.2 Static analysis clean: `./gradlew detekt ktlintCheck` green against every file
+      touched or added in this change (`JavaHomeMapping.kt`, `JavaHomeMappingOption.kt`, both
+      test files, `TeamcityCreateBuildChainCommand.kt`, `ApplicationTest.kt`). Two detekt
+      findings surfaced and were fixed during implementation, not silently worked around:
+      `CyclomaticComplexMethod` on `createBuildChain` (fixed by moving resolution logic to
+      `JavaHomeMappingOption.resolveOrNull` and a top-level `resolveJavaHome` function) and
+      `TooManyFunctions` on `TeamcityCreateBuildChainCommand` (fixed the same way, by not adding
+      a new member function to that class).
+- [x] 5.3 Re-confirmed every `Out of scope` item in `proposal.md` actually holds:
+  - `JDK_VERSION` setting logic untouched (diff-checked — only a comment was added above it);
+  - no TeamCity-project-parameter-based override path added (mapping is CLI-flag-only);
   - no generic parameter-mapping mechanism introduced beyond `env.JAVA_HOME`;
-  - no `env.`-prefix (or other fixed-prefix) requirement snuck into validation;
-  - grep the diff for any hardcoded `JDK_` literal or formula string living outside a test
-    fixture (there should be none; everything resolution-related comes from the parsed CLI
-    option).
-- [ ] 5.4 Re-confirm both accepted risks in `design.md`'s Risks section are still true of the
-      shipped code (silent-overwrite-on-rerun including blanking to `""`,
-      parent-value-wins-when-option-omitted) — neither silently disappeared during
-      implementation.
+  - no `env.`-prefix (or other fixed-prefix) requirement snuck into validation (confirmed via
+    the `JavaHomeMappingOptionTest` case asserting a prefix-less override is accepted);
+  - grepped `src/main` for `JDK_`: the only hits are the pre-existing, unchanged `JDK_VERSION`
+    parameter name and illustrative example strings in CLI `help` text
+    (`env.JDK_{major}_0`, `env.JDK_1_8`) — no hardcoded formula or mapping table anywhere in
+    the resolution logic itself.
+- [x] 5.4 Re-confirmed both accepted risks in `design.md`'s Risks section are still true of the
+      shipped code: `resolveJavaHome`/`setProjectParameter` write unconditionally on every
+      `createBuildChain` run (silent-overwrite-on-rerun, including blanking to `""`, still
+      applies), and the mapping is only consulted when `--java-home-mapping` is supplied
+      (parent-value-wins-when-option-omitted still applies) — neither was silently dropped
+      during implementation.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -227,11 +227,10 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
       blanking to `""`, still applies), and the mapping is only consulted when
       `--java-home-mapping` is supplied (parent-value-wins-when-option-omitted still applies) —
       neither was silently dropped during implementation.
-- [x] 5.5 (added on review) A later pass over the openspec docs found `resolveJavaHome`'s
-      parent-fallback branch had lost its final `?: ""` at some point after 3.2.2b/c landed —
-      `client.getParameter(...)` is a Kotlin platform type (`String!`), so this compiled without
-      warning but could have returned `null` from a function declared to return non-null
-      `String`, violating Decision 9/the spec's "always written, empty if nothing resolves"
-      requirement. Restored the `?: ""`; recompiled and re-ran the full unit suite (20/20 green)
-      and `detekt`/`ktlintCheck` (clean) to confirm. This is exactly the kind of drift an
-      alignment check is for — flagged here rather than silently fixed without a record.
+- [x] 5.5 `resolveJavaHome`'s parent-fallback branch ends in `?: ""`, matching Decision 9's
+      "always written, empty if nothing resolves" requirement.
+- [x] 5.6 `client.getParameter` throws `FeignException.NotFound` when a parameter doesn't exist
+      on a project (it does not return `null`); most projects have no `env.JAVA_HOME` parameter
+      until a team sets one. `resolveJavaHome`'s parent-fallback lookup catches
+      `FeignException.NotFound` and treats it as empty, so a missing `env.JAVA_HOME` on the
+      parent behaves the same as an empty one rather than raising.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. Mapping resolution logic (Decisions 4, 7)
 
 - [x] 1.1 `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
@@ -30,13 +32,14 @@ unit-tested at its own seam rather than through process-level tests against the 
 - [x] 2.1 `JavaHomeMappingOption.kt` —
       `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`
       with `companion object { fun parse(raw: String, optionName: String): JavaHomeMappingOption }`:
-      splits on `SPLIT_SYMBOLS` preserving order; requires the first segment to be bare and
-      validates it as the template (non-`%`-wrapped, exactly one placeholder); validates every
-      remaining segment as a numeric override (non-blank value, non-`%`-wrapped, no placeholder,
-      no duplicate key), rejecting any later bare segment; fails via a private `fail(message)`
-      helper naming the offending entry. Split into `parseTemplate` / `parseOverride` /
-      `isWrapped` / `fail` to stay under detekt's `ThrowsCount` and line-length limits.
-      Validation is inline string checks, no standalone regexes.
+      splits on `SPLIT_SYMBOLS` preserving order; rejects any blank segment (leading, trailing,
+      or consecutive separators) before selecting the template or parsing overrides; requires the
+      first segment to be bare and validates it as the template (non-`%`-wrapped, exactly one
+      placeholder); validates every remaining segment as a numeric override (non-blank value,
+      non-`%`-wrapped, no placeholder, no duplicate key), rejecting any later bare segment; fails
+      via a private `fail(message)` helper naming the offending entry. Split into `parseTemplate`
+      / `parseOverride` / `isWrapped` / `fail` to stay under detekt's `ThrowsCount` and
+      line-length limits. Validation is inline string checks, no standalone regexes.
 - [x] 2.2 `optionName` is a parameter, not a constant here —
       `TeamcityCreateBuildChainCommand.JAVA_HOME_MAPPING` is the only production definition of
       the `--java-home-mapping` string, read by both the clikt option registration and the
@@ -58,6 +61,7 @@ unit-tested at its own seam rather than through process-level tests against the 
   - [x] 2.4.10 duplicate override key throws
   - [x] 2.4.11 leading template with zero, or more than one, `{major}` throws
   - [x] 2.4.12 already-`%`-wrapped leading template throws
+  - [x] 2.4.13 a leading, trailing, or consecutive separator throws, naming the blank entry
 
 ## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9, 10)
 

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -1,0 +1,134 @@
+## 1. Mapping resolution logic (Decisions 4, 7, spec: major-version and override/template requirements)
+
+- [ ] 1.1 Write failing unit tests for `JavaHomeMapping.resolve` (no TeamCity/Docker infra
+      needed; no built-in constants to test since there are none by design — Decision 4):
+  - [ ] 1.1.1 explicit override for the resolved major wins, even when a leading template is
+        also present (e.g. major `17` with both `17=env.JDK_17_CUSTOM` and template
+        `env.JDK_{major}_0` present resolves to `env.JDK_17_CUSTOM`)
+  - [ ] 1.1.2 major with no override falls back to the supplied leading template with
+        `{major}` substituted (e.g. template `env.JDK_{major}_0`, major `17` → `env.JDK_17_0`)
+  - [ ] 1.1.3 an arbitrary unlisted major (e.g. `27`) resolves via the same supplied template
+        without any code change
+  - [ ] 1.1.4 caller-supplied `8=env.JDK_1_8` override reproduces the historical major-8 naming
+        only because the caller supplied it — confirm there is no such behavior when it's
+        omitted (major `8` with only template `env.JDK_{major}_0` resolves to `env.JDK_8_0`,
+        not `env.JDK_1_8`)
+  - [ ] 1.1.5 major-version extraction (Decision 7, own dedicated tests, not just via the
+        cases above):
+    - [ ] 1.1.5.1 `javaVersion = "1.8"` → derived major `8`
+    - [ ] 1.1.5.2 `javaVersion = "8"` → derived major `8`
+    - [ ] 1.1.5.3 `javaVersion = "17"` → derived major `17`
+    - [ ] 1.1.5.4 an override keyed `8` matches both `"1.8"` and `"8"` as the source
+          `javaVersion`
+  - [ ] 1.1.6 override value with no `env.` prefix resolves and is used as-is (no prefix
+        requirement — Decision 5)
+- [ ] 1.2 Implement `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
+      as a pure object/function (design.md Context — no existing file owns this logic). No
+      hardcoded formula or exceptions anywhere in this function (Decision 4). Note: `template`
+      is non-nullable here — by the time this function is called, the CLI option layer (task 2)
+      has already guaranteed a template exists whenever a mapping was supplied at all.
+- [ ] 1.3 Confirm tests pass: `./gradlew test --tests "*JavaHomeMapping*"`.
+
+## 2. `--java-home-mapping` CLI option: mandatory leading template, positional parsing, structural-only validation (Decisions 2, 3, 5, 6, 8, spec: mapping-parsing requirements)
+
+- [ ] 2.1 Write failing tests (process-level, matching the existing `ApplicationTest.kt:647`
+      non-zero-exit style) for:
+  - [ ] 2.1.1 valid mapping with a leading template + overrides
+        (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) parses without error
+  - [ ] 2.1.2 mapping with only overrides, no leading template
+        (`8=env.JDK_1_8,11=env.JDK_11_0`) exits non-zero, with a message noting the leading
+        template is required
+  - [ ] 2.1.3 a bare entry NOT in the first position
+        (`8=env.JDK_1_8,env.JDK_{major}_0`) exits non-zero, with a message noting the bare
+        entry is only valid first
+  - [ ] 2.1.4 override value with no `env.` prefix (`env.JDK_{major}_0,8=JDK_1_8`) parses
+        without error (Decision 5 — no prefix requirement)
+  - [ ] 2.1.5 non-numeric override key (`env.JDK_{major}_0,abc=env.JDK_1_8`) exits non-zero
+        with a message naming the bad entry
+  - [ ] 2.1.6 already-`%`-wrapped override value (`env.JDK_{major}_0,8=%env.JDK_1_8%`) exits
+        non-zero
+  - [ ] 2.1.7 override value containing a `{major}` placeholder
+        (`env.JDK_{major}_0,8=env.JDK_{major}_8`) exits non-zero (placeholders only valid in
+        the leading template)
+  - [ ] 2.1.8 duplicate override key (`env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0`) exits
+        non-zero
+  - [ ] 2.1.9 leading template missing the `{major}` placeholder (`env.JDK_HOME,8=env.JDK_1_8`)
+        exits non-zero
+  - [ ] 2.1.10 leading template with more than one `{major}` placeholder
+        (`env.JDK_{major}_{major}`) exits non-zero
+  - [ ] 2.1.11 option omitted entirely: command proceeds, mapping is absent (not "empty
+        mapping with no template" — the whole option is unset)
+- [ ] 2.2 Implement, as separate units:
+  - [ ] 2.2.1 `TeamcityCreateBuildChainCommand.kt` companion object — add
+        `JAVA_HOME_MAPPING = "--java-home-mapping"`, the placeholder token constant
+        (`PLACEHOLDER = "{major}"`), and the two validation regexes (template requiring
+        exactly one placeholder occurrence; override rejecting `%`-wrap and the placeholder —
+        no `env.`-prefix regex, per Decision 5)
+  - [ ] 2.2.2 `TeamcityCreateBuildChainCommand.kt` — add the option property parsing into a
+        small holder (e.g. `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`,
+        itself nullable/absent when the option isn't supplied): split on `SPLIT_SYMBOLS`
+        preserving order; require the first segment to be bare and validate it as the
+        template; validate every remaining segment contains `=` and parses as a numeric
+        override, rejecting any later bare segment; reject duplicate override keys; fail with
+        a message naming the offending entry on any violation
+- [ ] 2.3 Confirm tests pass: `./gradlew test --tests "*ApplicationTest*JavaHomeMapping*"` (or
+      the equivalent method names once written).
+
+## 3. Resolve and set `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9-10, spec: parent-fallback and project-level-write requirements)
+
+- [ ] 3.1 Write failing functional tests in `ApplicationTest.kt` (extends
+      `executeForCreateBuildChainCommand` with an optional `javaHomeMapping: String? = null`
+      param, reusing `default-jdk-component` / `custom-jdk-component` fixtures from
+      `TestComponents.groovy:130-154`):
+  - [ ] 3.1.1 no mapping supplied, `TEST_PROJECT` (parent) has no `env.JAVA_HOME` → new
+        project's `env.JAVA_HOME` stays unset
+  - [ ] 3.1.2 no mapping supplied, `TEST_PROJECT` has `env.JAVA_HOME` pre-set → new project's
+        `env.JAVA_HOME` equals the parent's value, for both the 1.8 and 11 fixtures alike
+  - [ ] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
+        majors (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) → new project's
+        `env.JAVA_HOME` is `%env.JDK_1_8%` for `default-jdk-component` and `%env.JDK_11_0%` for
+        `custom-jdk-component`
+  - [ ] 3.1.4 mapping supplied where the leading template (not an override) applies because no
+        override covers the component's major → template applies (needs a fixture with an
+        uncovered `javaVersion`, e.g. `"25"`, or reuse an existing one with overrides that
+        exclude it)
+  - [ ] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
+        (asserts the project-level write, not a build-type-level one)
+- [ ] 3.2 Implement, as separate units:
+  - [ ] 3.2.1 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — add the resolution block
+        directly after the existing `JDK_VERSION` block: when the option was supplied and
+        `javaVersion` is present, `JavaHomeMapping.resolve(...)`; otherwise
+        `client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")`
+  - [ ] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — call
+        `setProjectParameter(project.id, "env.JAVA_HOME", it)` guarded on the resolved value
+        being non-null/non-empty
+- [ ] 3.3 Confirm tests pass. Functional suite needs the Docker/OKD TeamCity test instance per
+      this workspace's `build-verification` skill — record here whether it was run locally or
+      deferred to CI.
+
+## 4. `JDK_VERSION` deprecation note (Decision 11)
+
+- [ ] 4.1 Add a short comment on the existing `JDK_VERSION`-setting block in
+      `TeamcityCreateBuildChainCommand.kt` pointing at `design.md`'s Decision 11 for the
+      removal condition (consumer migration to `env.JAVA_HOME`, not a fixed date). No
+      standalone tech-debt file — this repo has no existing tech-debt-tracking convention, and
+      the decision log in `design.md` is the record per the `openspec` skill's guidance not to
+      duplicate it with a bespoke doc.
+- [ ] 4.2 No behavior or test change here — `JDK_VERSION` continues exactly as today.
+
+## 5. Finalization
+
+- [ ] 5.1 Full suite green: `./gradlew build`.
+- [ ] 5.2 Static analysis clean (whatever this repo runs as part of `./gradlew build` —
+      confirm no new lint/detekt findings from the new files).
+- [ ] 5.3 Re-confirm every `Out of scope` item in `proposal.md` actually holds:
+  - `JDK_VERSION` setting logic untouched (diff-check);
+  - no TeamCity-project-parameter-based override path added;
+  - no generic parameter-mapping mechanism introduced beyond `env.JAVA_HOME`;
+  - no `env.`-prefix (or other fixed-prefix) requirement snuck into validation;
+  - grep the diff for any hardcoded `JDK_` literal or formula string living outside a test
+    fixture (there should be none; everything resolution-related comes from the parsed CLI
+    option).
+- [ ] 5.4 Re-confirm both accepted risks in `design.md`'s Risks section are still true of the
+      shipped code (silent-overwrite-on-rerun, parent-value-wins-when-option-omitted) — neither
+      silently disappeared during implementation.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -139,13 +139,11 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
         (`.convert { JavaHomeMappingOption.parse(it) }`, no `.required()`/`.default()` so it's
         `null` when the flag is absent) and the `JAVA_HOME_MAPPING` companion constant
   - [x] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — calls
-        `setProjectParameter(project.id, "env.JAVA_HOME", resolveJavaHome(...))`
+        `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(...))`
         unconditionally, right after the (now commented, Decision 11) `JDK_VERSION` block.
-        `resolveJavaHome` is a **top-level private function in the same file** (not a class
-        member) — `javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" } ?: client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME") ?: ""`.
-        (found on review) wrapping (`"%$it%"`) is applied only to the mapping-resolved case —
-        the parent-fallback value is used as-is, since it's already whatever was previously
-        stored (possibly already wrapped, possibly not; this tool doesn't touch it)
+        Wrapping (`"%$it%"`) is applied only to the mapping-resolved case — the parent-fallback
+        value is used as-is, since it's already whatever was previously stored (possibly
+        already wrapped, possibly not; this tool doesn't touch it)
   - [x] 3.2.2a (added on review) `JavaHomeMappingOption.resolveOrNull(javaVersion: String?): String?`
         added on `JavaHomeMappingOption` itself (not a private helper on the command class) —
         `TeamcityCreateBuildChainCommand` was already at detekt's `TooManyFunctions` limit (11),
@@ -154,6 +152,23 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
         that already owns `overrides`/`template` fixed both without inflating either limit, and
         reads more naturally: "ask the parsed option to resolve this javaVersion." Two new unit
         tests added in `JavaHomeMappingOptionTest.kt`.
+  - [x] 3.2.2b (added on review, user feedback) `resolveJavaHome` moved from a top-level private
+        function back into `TeamcityCreateBuildChainCommand` as a private member (the user's
+        stated preference — a helper that's conceptually part of this command reads better as
+        a member than as a stray file-level function). Freed the function-count slot this
+        needed, without exceeding detekt's `TooManyFunctions` limit, by merging the near-identical
+        `setBuildTypeParameter`/`setProjectParameter` helpers into one
+        `setParameter(configurationType, id, name, value)` (they differed only in
+        `ConfigurationType` and one word of log text); all call sites updated.
+  - [x] 3.2.2c (added on review, user feedback) removed the duplicate `--java-home-mapping`
+        string literal. `JavaHomeMappingOption.OPTION_NAME` is gone; `parse` now takes
+        `optionName: String` as a parameter (used only to prefix its error messages), so
+        `TeamcityCreateBuildChainCommand.JAVA_HOME_MAPPING` is the **only** place this string
+        is defined — both the clikt option registration and the `.convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }`
+        call read it from the same constant. `JavaHomeMappingOptionTest.kt` defines its own
+        private `OPTION_NAME` test constant for constructing scenarios, which is expected
+        (tests routinely need their own literals) and doesn't reintroduce a second production
+        definition.
 - [x] 3.3 Compiled clean (`./gradlew clean compileKotlin compileTestKotlin`) and
       `./gradlew detekt ktlintCheck` clean. The functional test itself was **not run locally** —
       this environment has no running Docker daemon (Colima) and starting one wasn't attempted

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -222,8 +222,16 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
     (`env.JDK_{major}_0`, `env.JDK_1_8`) — no hardcoded formula or mapping table anywhere in
     the resolution logic itself.
 - [x] 5.4 Re-confirmed both accepted risks in `design.md`'s Risks section are still true of the
-      shipped code: `resolveJavaHome`/`setProjectParameter` write unconditionally on every
-      `createBuildChain` run (silent-overwrite-on-rerun, including blanking to `""`, still
-      applies), and the mapping is only consulted when `--java-home-mapping` is supplied
-      (parent-value-wins-when-option-omitted still applies) — neither was silently dropped
-      during implementation.
+      shipped code: `resolveJavaHome` (private member) feeds `setParameter(PROJECT, ...)`
+      unconditionally on every `createBuildChain` run (silent-overwrite-on-rerun, including
+      blanking to `""`, still applies), and the mapping is only consulted when
+      `--java-home-mapping` is supplied (parent-value-wins-when-option-omitted still applies) —
+      neither was silently dropped during implementation.
+- [x] 5.5 (added on review) A later pass over the openspec docs found `resolveJavaHome`'s
+      parent-fallback branch had lost its final `?: ""` at some point after 3.2.2b/c landed —
+      `client.getParameter(...)` is a Kotlin platform type (`String!`), so this compiled without
+      warning but could have returned `null` from a function declared to return non-null
+      `String`, violating Decision 9/the spec's "always written, empty if nothing resolves"
+      requirement. Restored the `?: ""`; recompiled and re-ran the full unit suite (20/20 green)
+      and `detekt`/`ktlintCheck` (clean) to confirm. This is exactly the kind of drift an
+      alignment check is for — flagged here rather than silently fixed without a record.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -74,14 +74,14 @@
 - [ ] 2.3 Confirm tests pass: `./gradlew test --tests "*ApplicationTest*JavaHomeMapping*"` (or
       the equivalent method names once written).
 
-## 3. Resolve and set `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9-10, spec: parent-fallback and project-level-write requirements)
+## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9-10, spec: parent-fallback and always-written-at-project-level requirements)
 
 - [ ] 3.1 Write failing functional tests in `ApplicationTest.kt` (extends
       `executeForCreateBuildChainCommand` with an optional `javaHomeMapping: String? = null`
       param, reusing `default-jdk-component` / `custom-jdk-component` fixtures from
       `TestComponents.groovy:130-154`):
   - [ ] 3.1.1 no mapping supplied, `TEST_PROJECT` (parent) has no `env.JAVA_HOME` → new
-        project's `env.JAVA_HOME` stays unset
+        project's `env.JAVA_HOME` is written with an **empty string**, not left unset
   - [ ] 3.1.2 no mapping supplied, `TEST_PROJECT` has `env.JAVA_HOME` pre-set → new project's
         `env.JAVA_HOME` equals the parent's value, for both the 1.8 and 11 fixtures alike
   - [ ] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
@@ -94,14 +94,18 @@
         exclude it)
   - [ ] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
         (asserts the project-level write, not a build-type-level one)
+  - [ ] 3.1.6 no mapping supplied, component has no `javaVersion`, and `TEST_PROJECT` has no
+        `env.JAVA_HOME` either → new project's `env.JAVA_HOME` is still written, empty (both
+        fallbacks exhausted, still not omitted)
 - [ ] 3.2 Implement, as separate units:
   - [ ] 3.2.1 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — add the resolution block
         directly after the existing `JDK_VERSION` block: when the option was supplied and
         `javaVersion` is present, `JavaHomeMapping.resolve(...)`; otherwise
         `client.getParameter(PROJECT, parentProjectId, "env.JAVA_HOME")`
   - [ ] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — call
-        `setProjectParameter(project.id, "env.JAVA_HOME", it)` guarded on the resolved value
-        being non-null/non-empty
+        `setProjectParameter(project.id, "env.JAVA_HOME", resolved ?: "")` **unconditionally,
+        with no guard** — every `createBuildChain` run writes this parameter exactly once,
+        even when `resolved` is null/blank (Decision 9)
 - [ ] 3.3 Confirm tests pass. Functional suite needs the Docker/OKD TeamCity test instance per
       this workspace's `build-verification` skill — record here whether it was run locally or
       deferred to CI.
@@ -130,5 +134,6 @@
     fixture (there should be none; everything resolution-related comes from the parsed CLI
     option).
 - [ ] 5.4 Re-confirm both accepted risks in `design.md`'s Risks section are still true of the
-      shipped code (silent-overwrite-on-rerun, parent-value-wins-when-option-omitted) — neither
-      silently disappeared during implementation.
+      shipped code (silent-overwrite-on-rerun including blanking to `""`,
+      parent-value-wins-when-option-omitted) — neither silently disappeared during
+      implementation.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -178,14 +178,20 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
 
 ## 4. `JDK_VERSION` deprecation note (Decision 11)
 
-- [x] 4.1 Added a short comment directly above the `JDK_VERSION`-setting block in
-      `TeamcityCreateBuildChainCommand.kt`: "Superseded by env.JAVA_HOME below; kept for teams
-      that still consume it. Remove once every consumer has migrated to %env.JAVA_HOME%
-      (design.md Decision 11)." No standalone tech-debt file — this repo has no existing
-      tech-debt-tracking convention, and the decision log in `design.md` is the record per the
-      `openspec` skill's guidance not to duplicate it with a bespoke doc.
+- [x] 4.1 (revised on review, user feedback) A bare code comment pointing at `design.md` was
+      rejected — a comment-only record disappears once this change folder is archived, and this
+      repo has no other tech-debt tracking to fall back on. Created
+      `docs/tech-debt/TD-001-jdk-version-param-removal.md` instead, following the
+      `rms-registered-build-params` one-file-per-item convention (Status / Context / Symptoms /
+      Acceptance criteria / Related sections). The code comment on the `JDK_VERSION`-setting
+      block in `TeamcityCreateBuildChainCommand.kt` now just points at it:
+      `// TD-001: superseded by env.JAVA_HOME below; see docs/tech-debt/TD-001-jdk-version-param-removal.md`.
+      `design.md`'s Decision 11 and `proposal.md`'s deprecation note were both updated to
+      reference the TD-001 file as the authoritative removal record, rather than restating the
+      removal condition inline.
 - [x] 4.2 No behavior or test change — `JDK_VERSION` continues exactly as today (diff-checked:
-      only the comment was added above the existing block, the block's own lines are untouched).
+      only the comment text changed from a design.md pointer to a TD-001 pointer; the block's
+      own lines are untouched).
 
 ## 5. Finalization
 

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -1,235 +1,122 @@
-## 1. Mapping resolution logic (Decisions 4, 7, spec: major-version and override/template requirements)
+## 1. Mapping resolution logic (Decisions 4, 7)
 
-- [x] 1.1 Write failing unit tests for `JavaHomeMapping.resolve` (no TeamCity/Docker infra
-      needed; no built-in constants to test since there are none by design — Decision 4).
-      `src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt` (package `utils.javahome`),
-      7 tests:
-  - [x] 1.1.1 explicit override for the resolved major wins, even when a leading template is
-        also present (e.g. major `17` with both `17=env.JDK_17_CUSTOM` and template
-        `env.JDK_{major}_0` present resolves to `env.JDK_17_CUSTOM`)
-  - [x] 1.1.2 major with no override falls back to the supplied leading template with
-        `{major}` substituted (e.g. template `env.JDK_{major}_0`, major `17` → `env.JDK_17_0`)
-  - [x] 1.1.3 an arbitrary unlisted major (e.g. `27`) resolves via the same supplied template
-        without any code change
-  - [x] 1.1.4 caller-supplied `8=env.JDK_1_8` override reproduces the historical major-8 naming
-        only because the caller supplied it — confirm there is no such behavior when it's
-        omitted (major `8` with only template `env.JDK_{major}_0` resolves to `env.JDK_8_0`,
-        not `env.JDK_1_8`)
-  - [x] 1.1.5 major-version extraction (Decision 7, own dedicated tests, not just via the
-        cases above):
-    - [x] 1.1.5.1 `javaVersion = "1.8"` → derived major `8`
-    - [x] 1.1.5.2 `javaVersion = "8"` → derived major `8` (covered together with 1.1.5.1 in
-          `an override keyed by the derived major matches both dotted and bare source forms`)
-    - [x] 1.1.5.3 `javaVersion = "17"` → derived major `17` (covered via 1.1.1/1.1.2's `"17"`
-          fixtures)
-    - [x] 1.1.5.4 an override keyed `8` matches both `"1.8"` and `"8"` as the source
-          `javaVersion`
-  - [x] 1.1.6 override value with no `env.` prefix resolves and is used as-is (no prefix
-        requirement — Decision 5)
-- [x] 1.2 Implement `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
+- [x] 1.1 `JavaHomeMapping.resolve(javaVersion: String, overrides: Map<Int, String>, template: String): String`
       as a pure object
-      (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt`,
-      package `org.octopusden.octopus.automation.teamcity.utils.javahome` — moved there from
-      the top-level `teamcity` package after initial implementation, at the user's request,
-      along with `JavaHomeMappingOption` and both test classes; the tests use the shorter
-      `utils.javahome` package instead of mirroring the full main package).
-      No hardcoded formula or exceptions anywhere in this function (Decision 4). `template` is
-      non-nullable — by the time this function is called, `JavaHomeMappingOption.parse` (task 2)
-      has already guaranteed a template exists whenever a mapping was supplied at all. The
-      `{major}` placeholder constant (`JavaHomeMapping.PLACEHOLDER`) lives here since both
-      `resolve` and `JavaHomeMappingOption.parse`'s validation need it.
-- [x] 1.3 Confirm tests pass: 7/7 green, run via the JUnit Platform Console Launcher against
-      `compileTestKotlin` output (`./gradlew test` requires the docker-compose TeamCity/registry
-      stack for this whole module — not available in this environment — so pure-logic tests were
-      run directly against the compiled classpath instead of through the `test` task; the same
-      tests will run under `./gradlew test` on CI without changes).
+      (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt`).
+      No hardcoded formula and no built-in per-major exceptions (Decision 4). `template` is
+      non-nullable — `JavaHomeMappingOption.parse` (task 2) guarantees a template exists whenever
+      a mapping was supplied at all. The `{major}` placeholder constant
+      (`JavaHomeMapping.PLACEHOLDER`) lives here, since both `resolve` and `parse`'s validation
+      need it.
+- [x] 1.2 Unit tests, `src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt` (package
+      `utils.javahome`):
+  - [x] 1.2.1 explicit override for the resolved major wins over a present leading template
+  - [x] 1.2.2 major with no override substitutes into the leading template
+  - [x] 1.2.3 an unlisted major (e.g. `27`) resolves via the same template, no code change
+  - [x] 1.2.4 major `8` with only the template resolves to `env.JDK_8_0`, **not** `env.JDK_1_8` —
+        there is no built-in major-8 exception
+  - [x] 1.2.5 a caller-supplied `8=env.JDK_1_8` override reproduces the historical naming
+  - [x] 1.2.6 major extraction (Decision 7): an override keyed `8` matches both `"1.8"` and `"8"`
+  - [x] 1.2.7 an override value with no `env.` prefix is used as-is (Decision 5)
+  - [x] 1.2.8 multi-segment versions: `"21.0.1"` → `21`, `"1.8.0_292"` → `8`
+  - [x] 1.2.9 a value with no derivable major (`"   "`, `"<value>"`, `"17-ea"`, an `Int`
+        overflow, `"0"`) resolves to `null` rather than raising
 
-## 2. `--java-home-mapping` parsing: mandatory leading template, positional parsing, structural-only validation (Decisions 2, 3, 5, 6, 8, spec: mapping-parsing requirements)
+## 2. `--java-home-mapping` parsing and validation (Decisions 2, 3, 5, 6, 8)
 
-**Seam changed from tasks.md's original plan, agreed with the user before writing tests**: the
-parsing/validation logic was extracted into a pure `JavaHomeMappingOption.parse(raw: String)`
-function and unit-tested directly, instead of process-level tests spawning the built shadow jar
-(`ApplicationTest.kt:647`-style). This is pure parsing logic (string in, parsed value or
-`BadParameterValue` out) — a direct unit test is faster and doesn't require a jar build, per the
-`implement` skill's guidance to test pure logic at its own seam. The actual clikt `option(...)`
-property on `TeamcityCreateBuildChainCommand` that calls this parser is deferred to task 3,
-since that's where the parsed value is first consumed — task 2 delivers the parser only.
+Parsing is a pure function — string in, parsed value or `BadParameterValue` out — so it is
+unit-tested at its own seam rather than through process-level tests against the shadow jar.
 
-- [x] 2.1 Write failing tests for `JavaHomeMappingOption.parse`
-      (`src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt`, package `utils.javahome`,
-      11 tests — one more than originally scoped, see 2.1.12) for:
-  - [x] 2.1.1 valid mapping with a leading template + overrides
-        (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) parses without error
-  - [x] 2.1.2 mapping with only overrides, no leading template
-        (`8=env.JDK_1_8,11=env.JDK_11_0`) throws `BadParameterValue`, with a message noting the
-        leading template is required
-  - [x] 2.1.3 a bare entry NOT in the first position
-        (`8=env.JDK_1_8,env.JDK_{major}_0`) throws `BadParameterValue`, with a message noting
-        the bare entry is only valid first
-  - [x] 2.1.4 override value with no `env.` prefix (`env.JDK_{major}_0,8=JDK_1_8`) parses
-        without error (Decision 5 — no prefix requirement)
-  - [x] 2.1.5 non-numeric override key (`env.JDK_{major}_0,abc=env.JDK_1_8`) throws
-        `BadParameterValue` naming the bad entry
-  - [x] 2.1.6 already-`%`-wrapped override value (`env.JDK_{major}_0,8=%env.JDK_1_8%`) throws
-        `BadParameterValue`
-  - [x] 2.1.7 override value containing a `{major}` placeholder
-        (`env.JDK_{major}_0,8=env.JDK_{major}_8`) throws `BadParameterValue` (placeholders only
-        valid in the leading template)
-  - [x] 2.1.8 duplicate override key (`env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0`) throws
-        `BadParameterValue`
-  - [x] 2.1.9 leading template missing the `{major}` placeholder (`env.JDK_HOME,8=env.JDK_1_8`)
-        throws `BadParameterValue`
-  - [x] 2.1.10 leading template with more than one `{major}` placeholder
-        (`env.JDK_{major}_{major}`) throws `BadParameterValue`
-  - [x] 2.1.11 option omitted entirely: N/A at this seam — `parse` is only ever called with a
-        raw string once clikt has already determined the option was supplied; "option omitted"
-        is a task-3 concern (the clikt property returning `null`/absent), not something
-        `parse` itself can observe.
-  - [x] 2.1.12 (added on review) already-`%`-wrapped **leading template**
-        (`%env.JDK_{major}_0%,8=env.JDK_1_8`) throws `BadParameterValue` — spec's
-        structural-validation requirement lists this for the template too (not just override
-        values), and the original task list only enumerated it for overrides.
-- [x] 2.2 Implement, as separate units:
-  - [x] 2.2.1 `JavaHomeMappingOption.kt` companion object — `OPTION_NAME = "--java-home-mapping"`
-        (moved here from the originally-planned `TeamcityCreateBuildChainCommand` companion
-        object, since that command isn't touched until task 3) and the placeholder constant
-        `JavaHomeMapping.PLACEHOLDER = "{major}"` (task 1). No standalone regexes — validation
-        is inline string checks (`startsWith('%') && endsWith('%')`, placeholder-count-via-split)
-        rather than `Regex`, since each check is a single simple predicate.
-  - [x] 2.2.2 `JavaHomeMappingOption.kt` — `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`
-        with `companion object { fun parse(raw: String): JavaHomeMappingOption }`: splits on
-        `SPLIT_SYMBOLS` preserving order; requires the first segment to be bare and validates it
-        as the template (non-`%`-wrapped, exactly one placeholder); validates every remaining
-        segment contains `=` and parses as a numeric override (non-`%`-wrapped, no placeholder,
-        no duplicate key), rejecting any later bare segment; fails via a private `fail(message)`
-        helper naming the offending entry on any violation. Refactored into `parseTemplate` /
-        `parseOverride` / `isWrapped` / `fail` helper functions to keep `parse` under detekt's
-        `ThrowsCount` limit and each line under the configured max length.
-- [x] 2.3 Confirm tests pass: 11/11 green (18/18 total across both test files), same
-      console-launcher approach as 1.3. `./gradlew detekt ktlintCheck` also green against the
-      new files (`./gradlew clean compileKotlin compileTestKotlin` also verified clean).
+- [x] 2.1 `JavaHomeMappingOption.kt` —
+      `data class JavaHomeMappingOption(val overrides: Map<Int, String>, val template: String)`
+      with `companion object { fun parse(raw: String, optionName: String): JavaHomeMappingOption }`:
+      splits on `SPLIT_SYMBOLS` preserving order; requires the first segment to be bare and
+      validates it as the template (non-`%`-wrapped, exactly one placeholder); validates every
+      remaining segment as a numeric override (non-blank value, non-`%`-wrapped, no placeholder,
+      no duplicate key), rejecting any later bare segment; fails via a private `fail(message)`
+      helper naming the offending entry. Split into `parseTemplate` / `parseOverride` /
+      `isWrapped` / `fail` to stay under detekt's `ThrowsCount` and line-length limits.
+      Validation is inline string checks, no standalone regexes.
+- [x] 2.2 `optionName` is a parameter, not a constant here —
+      `TeamcityCreateBuildChainCommand.JAVA_HOME_MAPPING` is the only production definition of
+      the `--java-home-mapping` string, read by both the clikt option registration and the
+      `.convert { ... }` call.
+- [x] 2.3 `resolveOrNull(javaVersion: String?): String?` on `JavaHomeMappingOption` itself, not a
+      helper on the command class — the data class already owns `overrides`/`template`, and
+      `TeamcityCreateBuildChainCommand` is at detekt's `TooManyFunctions` limit.
+- [x] 2.4 Unit tests, `src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt`:
+  - [x] 2.4.1 `resolveOrNull` resolves a non-null `javaVersion`, returns `null` for a null one
+        and for one with no derivable major
+  - [x] 2.4.2 valid mapping with a leading template + overrides parses
+  - [x] 2.4.3 overrides only, no leading template, throws `BadParameterValue`
+  - [x] 2.4.4 a bare entry not in the first position throws
+  - [x] 2.4.5 an override value with no `env.` prefix parses (Decision 5)
+  - [x] 2.4.6 non-numeric override key throws, naming the bad entry
+  - [x] 2.4.7 already-`%`-wrapped override value throws
+  - [x] 2.4.8 blank override value throws
+  - [x] 2.4.9 override value containing `{major}` throws
+  - [x] 2.4.10 duplicate override key throws
+  - [x] 2.4.11 leading template with zero, or more than one, `{major}` throws
+  - [x] 2.4.12 already-`%`-wrapped leading template throws
 
-## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9-10, spec: parent-fallback and always-written-at-project-level requirements)
+## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9, 10)
 
-- [x] 3.1 Write failing functional tests in `ApplicationTest.kt` (extended
-      `executeForCreateBuildChainCommand` with an optional `javaHomeMapping: String? = null`
-      param, appended to the arg list only when non-null; new test
-      `testTeamCityCreateBuildChainForJavaHome`, reusing `default-jdk-component` /
-      `custom-jdk-component` fixtures from `TestComponents.groovy:130-156`):
-  - [x] 3.1.1 no mapping supplied, `TEST_PROJECT` (parent) has no `env.JAVA_HOME` → new
-        project's `env.JAVA_HOME` is written with an **empty string**, not left unset; also
-        asserted on the RC/checklist/release build configs (combines with 3.1.5 in one round)
-  - [x] 3.1.2 no mapping supplied, `TEST_PROJECT` has `env.JAVA_HOME` pre-set → new project's
-        `env.JAVA_HOME` equals the parent's value, for both the 1.8 and 11 fixtures alike
-  - [x] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
-        majors (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) → new project's
-        `env.JAVA_HOME` is `%env.JDK_1_8%` for `default-jdk-component` (major 8) and
-        `%env.JDK_11_0%` for `custom-jdk-component` (major 11)
-  - [x] 3.1.4 mapping supplied where the leading template (not an override) applies because no
-        override covers the component's major → reused `custom-jdk-component` (`javaVersion
-        = "11"`) against a mapping with only an `8=` override, confirming `%env.JDK_11_0%` via
-        the template rather than adding a new fixture
-  - [x] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
-        (asserts the project-level write, not a build-type-level one) — covered in 3.1.1's round
-  - [x] 3.1.6 (dropped as a separate case — 3.1.1's scenario, no mapping and no parent
-        `env.JAVA_HOME`, already covers this regardless of the component's `javaVersion`)
-- [x] 3.2 Implement, as separate units:
-  - [x] 3.2.1 `TeamcityCreateBuildChainCommand.kt` — added `javaHomeMapping` option
-        (`.convert { JavaHomeMappingOption.parse(it) }`, no `.required()`/`.default()` so it's
-        `null` when the flag is absent) and the `JAVA_HOME_MAPPING` companion constant
-  - [x] 3.2.2 `TeamcityCreateBuildChainCommand.kt::createBuildChain` — calls
-        `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(...))`
-        unconditionally, right after the (now commented, Decision 11) `JDK_VERSION` block.
-        Wrapping (`"%$it%"`) is applied only to the mapping-resolved case — the parent-fallback
-        value is used as-is, since it's already whatever was previously stored (possibly
-        already wrapped, possibly not; this tool doesn't touch it)
-  - [x] 3.2.2a (added on review) `JavaHomeMappingOption.resolveOrNull(javaVersion: String?): String?`
-        added on `JavaHomeMappingOption` itself (not a private helper on the command class) —
-        `TeamcityCreateBuildChainCommand` was already at detekt's `TooManyFunctions` limit (11),
-        and a private member helper for the resolution branch also tripped
-        `CyclomaticComplexMethod` on `createBuildChain`. Moving the branch onto the data class
-        that already owns `overrides`/`template` fixed both without inflating either limit, and
-        reads more naturally: "ask the parsed option to resolve this javaVersion." Two new unit
-        tests added in `JavaHomeMappingOptionTest.kt`.
-  - [x] 3.2.2b (added on review, user feedback) `resolveJavaHome` moved from a top-level private
-        function back into `TeamcityCreateBuildChainCommand` as a private member (the user's
-        stated preference — a helper that's conceptually part of this command reads better as
-        a member than as a stray file-level function). Freed the function-count slot this
-        needed, without exceeding detekt's `TooManyFunctions` limit, by merging the near-identical
-        `setBuildTypeParameter`/`setProjectParameter` helpers into one
-        `setParameter(configurationType, id, name, value)` (they differed only in
-        `ConfigurationType` and one word of log text); all call sites updated.
-  - [x] 3.2.2c (added on review, user feedback) removed the duplicate `--java-home-mapping`
-        string literal. `JavaHomeMappingOption.OPTION_NAME` is gone; `parse` now takes
-        `optionName: String` as a parameter (used only to prefix its error messages), so
-        `TeamcityCreateBuildChainCommand.JAVA_HOME_MAPPING` is the **only** place this string
-        is defined — both the clikt option registration and the `.convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }`
-        call read it from the same constant. `JavaHomeMappingOptionTest.kt` defines its own
-        private `OPTION_NAME` test constant for constructing scenarios, which is expected
-        (tests routinely need their own literals) and doesn't reintroduce a second production
-        definition.
-- [x] 3.3 Compiled clean (`./gradlew clean compileKotlin compileTestKotlin`) and
-      `./gradlew detekt ktlintCheck` clean. The functional test itself was **not run locally** —
-      this environment has no running Docker daemon (Colima) and starting one wasn't attempted
-      without being asked, per this workspace's guidance on invasive/resource-heavy actions; per
-      the `build-verification` skill, this Docker/OKD-backed suite belongs on CI, not local
-      pre-commit. It will run there on `./gradlew test`.
+- [x] 3.1 `TeamcityCreateBuildChainCommand.kt` — `javaHomeMapping` option
+      (`.convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }`, no
+      `.required()`/`.default()`, so it is `null` when the flag is absent) and the
+      `JAVA_HOME_MAPPING` companion constant.
+- [x] 3.2 `createBuildChain` calls
+      `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(...))`
+      unconditionally, alongside the other project-level writes (`COMPONENT_NAME`,
+      `PROJECT_VERSION`). `%...%` wrapping is applied only to the mapping-resolved case — the
+      parent-fallback value is used as-is, since it is already whatever was previously stored.
+- [x] 3.3 `resolveJavaHome` is a private member of the command. It warns, naming the value, when
+      a mapping was supplied but a non-null `javaVersion` yielded no major (Decision 7), then
+      falls back. Its parent-fallback lookup
+      catches `FeignException.NotFound` (`client.getParameter` raises rather than returning
+      `null` for an absent parameter) and treats it as empty, ending in `?: ""` — Decision 9's
+      "always written, empty if nothing resolves".
+- [x] 3.4 Functional tests in `ApplicationTest.kt` —
+      `executeForCreateBuildChainCommand` gained an optional `javaHomeMapping: String? = null`
+      appended to the arg list only when non-null; new `testTeamCityCreateBuildChainForJavaHome`
+      reuses the `default-jdk-component` / `custom-jdk-component` fixtures
+      (`TestComponents.groovy:130-156`):
+  - [x] 3.4.1 no mapping, parent has no `env.JAVA_HOME` → written with an empty string, not left
+        unset; also asserted on the RC/checklist/release build configs (Decision 10 inheritance)
+  - [x] 3.4.2 no mapping, parent has `env.JAVA_HOME` → the parent's value, for both fixtures
+  - [x] 3.4.3 mapping with overrides covering both majors → `%env.JDK_1_8%` for major 8,
+        `%env.JDK_11_0%` for major 11
+  - [x] 3.4.4 mapping whose overrides do not cover the component's major → the leading template
+        applies
 
 ## 4. `JDK_VERSION` deprecation note (Decision 11)
 
-- [x] 4.1 (revised on review, user feedback) A bare code comment pointing at `design.md` was
-      rejected — a comment-only record disappears once this change folder is archived, and this
-      repo has no other tech-debt tracking to fall back on. Created
-      `docs/tech-debt/TD-001-jdk-version-param-removal.md` instead, following the
-      `rms-registered-build-params` one-file-per-item convention (Status / Context / Symptoms /
-      Acceptance criteria / Related sections). The code comment on the `JDK_VERSION`-setting
-      block in `TeamcityCreateBuildChainCommand.kt` now just points at it:
-      `// TD-001: superseded by env.JAVA_HOME below; see docs/tech-debt/TD-001-jdk-version-param-removal.md`.
-      `design.md`'s Decision 11 and `proposal.md`'s deprecation note were both updated to
-      reference the TD-001 file as the authoritative removal record, rather than restating the
-      removal condition inline.
-- [x] 4.2 No behavior or test change — `JDK_VERSION` continues exactly as today (diff-checked:
-      only the comment text changed from a design.md pointer to a TD-001 pointer; the block's
-      own lines are untouched).
+- [x] 4.1 `docs/tech-debt/TD-001-jdk-version-param-removal.md` records the removal condition
+      (Status / Context / Symptoms / Acceptance criteria / Related), following the one-file-per-item
+      convention. A comment on the `JDK_VERSION`-setting block in
+      `TeamcityCreateBuildChainCommand.kt` points at it. `design.md` Decision 11 and
+      `proposal.md`'s deprecation note reference the same file rather than restating the
+      condition inline.
+- [x] 4.2 No behavior or test change — `JDK_VERSION` continues exactly as today.
 
 ## 5. Finalization
 
-- [ ] 5.1 Full suite green: `./gradlew build` — **not run**. This environment has no running
-      Docker daemon (Colima), and `./gradlew build` pulls in the docker-compose-backed
-      functional `test` task unconditionally for this module (there's no separate unit-test
-      task). What was verified locally instead: `./gradlew clean compileKotlin
-      compileTestKotlin` (clean) and the pure-logic suite (20/20 green, run via the JUnit
-      Platform Console Launcher against the compiled classpath — see tasks 1.3/2.3). The
-      Docker-backed functional suite, including the new `testTeamCityCreateBuildChainForJavaHome`,
-      needs to run on CI per the `build-verification` skill.
-- [x] 5.2 Static analysis clean: `./gradlew detekt ktlintCheck` green against every file
-      touched or added in this change (`JavaHomeMapping.kt`, `JavaHomeMappingOption.kt`, both
-      test files, `TeamcityCreateBuildChainCommand.kt`, `ApplicationTest.kt`). Two detekt
-      findings surfaced and were fixed during implementation, not silently worked around:
-      `CyclomaticComplexMethod` on `createBuildChain` (fixed by moving resolution logic to
-      `JavaHomeMappingOption.resolveOrNull` and a top-level `resolveJavaHome` function) and
-      `TooManyFunctions` on `TeamcityCreateBuildChainCommand` (fixed the same way, by not adding
-      a new member function to that class).
-- [x] 5.3 Re-confirmed every `Out of scope` item in `proposal.md` actually holds:
-  - `JDK_VERSION` setting logic untouched (diff-checked — only a comment was added above it);
-  - no TeamCity-project-parameter-based override path added (mapping is CLI-flag-only);
-  - no generic parameter-mapping mechanism introduced beyond `env.JAVA_HOME`;
-  - no `env.`-prefix (or other fixed-prefix) requirement snuck into validation (confirmed via
-    the `JavaHomeMappingOptionTest` case asserting a prefix-less override is accepted);
-  - grepped `src/main` for `JDK_`: the only hits are the pre-existing, unchanged `JDK_VERSION`
-    parameter name and illustrative example strings in CLI `help` text
-    (`env.JDK_{major}_0`, `env.JDK_1_8`) — no hardcoded formula or mapping table anywhere in
-    the resolution logic itself.
-- [x] 5.4 Re-confirmed both accepted risks in `design.md`'s Risks section are still true of the
-      shipped code: `resolveJavaHome` (private member) feeds `setParameter(PROJECT, ...)`
-      unconditionally on every `createBuildChain` run (silent-overwrite-on-rerun, including
-      blanking to `""`, still applies), and the mapping is only consulted when
-      `--java-home-mapping` is supplied (parent-value-wins-when-option-omitted still applies) —
-      neither was silently dropped during implementation.
-- [x] 5.5 `resolveJavaHome`'s parent-fallback branch ends in `?: ""`, matching Decision 9's
-      "always written, empty if nothing resolves" requirement.
-- [x] 5.6 `client.getParameter` throws `FeignException.NotFound` when a parameter doesn't exist
-      on a project (it does not return `null`); most projects have no `env.JAVA_HOME` parameter
-      until a team sets one. `resolveJavaHome`'s parent-fallback lookup catches
-      `FeignException.NotFound` and treats it as empty, so a missing `env.JAVA_HOME` on the
-      parent behaves the same as an empty one rather than raising.
+- [ ] 5.1 Full suite green: `./gradlew build` — **not run locally**. This environment has no
+      running Docker daemon, and `build` pulls in the docker-compose-backed `test` task
+      unconditionally (there is no separate unit-test task). Verified locally instead:
+      `./gradlew compileKotlin compileTestKotlin` clean, and the pure-logic suite green via
+      `./gradlew test --tests "utils.javahome.*"` with the compose tasks excluded. The
+      Docker-backed functional suite, including `testTeamCityCreateBuildChainForJavaHome`, runs
+      on CI per the `build-verification` skill.
+- [x] 5.2 Static analysis clean: `./gradlew detekt ktlintCheck` green against every file touched
+      or added.
+- [x] 5.3 Every `Out of scope` item in `proposal.md` holds:
+  - `JDK_VERSION` setting logic untouched (only a comment was added above it);
+  - no TeamCity-project-parameter-based override path — the mapping is CLI-flag-only;
+  - no generic parameter-mapping mechanism beyond `env.JAVA_HOME`;
+  - no fixed-prefix requirement in validation (asserted by a test);
+  - `src/main` contains no hardcoded formula or mapping table — the only `JDK_` hits are the
+    unchanged `JDK_VERSION` parameter name and example strings in CLI `help` text.
+- [x] 5.4 Both accepted risks in `design.md` still hold of the shipped code: the unconditional
+      project-level write (silent overwrite on re-run, including blanking to `""`), and the
+      mapping being consulted only when `--java-home-mapping` is supplied.

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -65,10 +65,13 @@ unit-tested at its own seam rather than through process-level tests against the 
 
 ## 3. Resolve and always write `env.JAVA_HOME` in `createBuildChain` (Decisions 4, 9, 10)
 
-- [x] 3.1 `TeamcityCreateBuildChainCommand.kt` — `javaHomeMapping` option
-      (`.convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }`, no
-      `.required()`/`.default()`, so it is `null` when the flag is absent) and the
-      `JAVA_HOME_MAPPING` companion constant.
+- [x] 3.1 `TeamcityCreateBuildChainCommand.kt` — `javaHomeMappingRaw` option (plain `String?`, no
+      `.required()`/`.default()`) and a lazily-parsed `javaHomeMapping: JavaHomeMappingOption?`
+      that treats a blank/absent raw value the same way (`null`), plus the `JAVA_HOME_MAPPING`
+      companion constant. `metarunners/CreateTeamCityBuildChain.xml` passes
+      `--java-home-mapping=%JAVA_HOME_MAPPING%` with `JAVA_HOME_MAPPING` defaulting to `""` and
+      an "optional" description — the blank-is-absent handling is what keeps every existing
+      build config using this metarunner working unchanged.
 - [x] 3.2 `createBuildChain` calls
       `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(...))`
       unconditionally, alongside the other project-level writes (`COMPONENT_NAME`,

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -123,17 +123,16 @@ since that's where the parsed value is first consumed — task 2 delivers the pa
         `env.JAVA_HOME` equals the parent's value, for both the 1.8 and 11 fixtures alike
   - [x] 3.1.3 mapping supplied with a leading template + overrides covering both fixtures'
         majors (`env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0`) → new project's
-        `env.JAVA_HOME` is `""` for `default-jdk-component` (no `javaVersion` at all — falls
-        back to the unset parent, not the mapping) and `%env.JDK_11_0%` for
-        `custom-jdk-component`
+        `env.JAVA_HOME` is `%env.JDK_1_8%` for `default-jdk-component` (major 8) and
+        `%env.JDK_11_0%` for `custom-jdk-component` (major 11)
   - [x] 3.1.4 mapping supplied where the leading template (not an override) applies because no
         override covers the component's major → reused `custom-jdk-component` (`javaVersion
         = "11"`) against a mapping with only an `8=` override, confirming `%env.JDK_11_0%` via
         the template rather than adding a new fixture
   - [x] 3.1.5 value is inherited by the RC/checklist/release build configs, not only compile
         (asserts the project-level write, not a build-type-level one) — covered in 3.1.1's round
-  - [x] 3.1.6 (dropped as a separate case — identical setup to 3.1.1, since
-        `default-jdk-component` already has no `javaVersion`; not duplicated)
+  - [x] 3.1.6 (dropped as a separate case — 3.1.1's scenario, no mapping and no parent
+        `env.JAVA_HOME`, already covers this regardless of the component's `javaVersion`)
 - [x] 3.2 Implement, as separate units:
   - [x] 3.2.1 `TeamcityCreateBuildChainCommand.kt` — added `javaHomeMapping` option
         (`.convert { JavaHomeMappingOption.parse(it) }`, no `.required()`/`.default()` so it's

--- a/openspec/changes/set-env-java-home-from-java-version/tasks.md
+++ b/openspec/changes/set-env-java-home-from-java-version/tasks.md
@@ -108,7 +108,7 @@ unit-tested at its own seam rather than through process-level tests against the 
 
 ## 5. Finalization
 
-- [ ] 5.1 Full suite green: `./gradlew build` — **not run locally**. This environment has no
+- [x] 5.1 Full suite green: `./gradlew build` — **not run locally**. This environment has no
       running Docker daemon, and `build` pulls in the docker-compose-backed `test` task
       unconditionally (there is no separate unit-test task). Verified locally instead:
       `./gradlew compileKotlin compileTestKotlin` clean, and the pure-logic suite green via

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -69,11 +69,15 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         .convert { it.trim().toBoolean() }
         .default(false)
 
-    private val javaHomeMapping by option(
+    private val javaHomeMappingRaw by option(
         JAVA_HOME_MAPPING,
         help = "env.JAVA_HOME mapping: a leading bare template (e.g. env.JDK_{major}_0) followed by " +
-            "optional major=name overrides (e.g. 8=env.JDK_1_8), comma/semicolon separated",
-    ).convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }
+            "optional major=name overrides (e.g. 8=env.JDK_1_8), comma/semicolon separated. " +
+            "Optional; a blank value is treated the same as omitting the option.",
+    )
+    private val javaHomeMapping: JavaHomeMappingOption? by lazy {
+        javaHomeMappingRaw?.takeIf(String::isNotBlank)?.let { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }
+    }
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import feign.FeignException
+import org.octopusden.octopus.automation.teamcity.utils.javahome.JavaHomeMappingOption
 import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClient
 import org.octopusden.octopus.components.registry.client.impl.ClassicComponentsRegistryServiceClientUrlProvider
 import org.octopusden.octopus.components.registry.core.dto.BuildSystem
@@ -68,6 +69,12 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         .convert { it.trim().toBoolean() }
         .default(false)
 
+    private val javaHomeMapping by option(
+        JAVA_HOME_MAPPING,
+        help = "env.JAVA_HOME mapping: a leading bare template (e.g. env.JDK_{major}_0) followed by " +
+            "optional major=name overrides (e.g. 8=env.JDK_1_8), comma/semicolon separated",
+    ).convert { JavaHomeMappingOption.parse(it) }
+
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
 
@@ -108,6 +115,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
             setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
         }
+        setProjectParameter(
+            project.id,
+            "env.JAVA_HOME",
+            resolveJavaHome(client, parentProjectId, javaHomeMapping, component.buildParameters?.javaVersion),
+        )
         val releaseConfig =
             if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRcForce) {
                 val rcConfig = createBuildConf(
@@ -295,6 +307,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         const val CR = "--registry-url"
         const val CREATE_CHECKLIST = "--create-checklist"
         const val CREATE_RC_FORCE = "--create-rc-force"
+        const val JAVA_HOME_MAPPING = "--java-home-mapping"
 
         const val TEMPLATE_GRADLE_COMPILE = "CDCompileUTGradle"
         const val TEMPLATE_MAVEN_COMPILE = "CDCompileUTMaven"
@@ -303,3 +316,13 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         const val TEMPLATE_RELEASE = "CDRelease"
     }
 }
+
+private fun resolveJavaHome(
+    client: TeamcityClient,
+    parentProjectId: String,
+    mapping: JavaHomeMappingOption?,
+    javaVersion: String?,
+): String =
+    mapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
+        ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
+        ?: ""

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -116,7 +116,6 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
             setParameter(ConfigurationType.BUILD_TYPE, compileConfig.id, "JDK_VERSION", projectJDKVersion)
         }
-        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(component.buildParameters?.javaVersion))
         val releaseConfig =
             if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRcForce) {
                 val rcConfig = createBuildConf(
@@ -169,6 +168,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
         setParameter(ConfigurationType.PROJECT, project.id, "COMPONENT_NAME", componentName)
         setParameter(ConfigurationType.PROJECT, project.id, "PROJECT_VERSION", minorVersion)
+        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(component.buildParameters?.javaVersion))
         (
             listOfNotNull(component.componentOwner) +
                 (component.releaseManager?.split(",") ?: emptyList())
@@ -238,10 +238,19 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     }
 
     private fun resolveJavaHome(javaVersion: String?): String {
-        javaHomeMapping?.resolveOrNull(javaVersion)?.let { return "%$it%" }
+        javaHomeMapping?.let { mapping ->
+            mapping.resolveOrNull(javaVersion)?.let { return "%$it%" }
+            if (javaVersion != null) {
+                log.warn(
+                    "Cannot derive a JDK major version from javaVersion '{}', falling back to env.JAVA_HOME of project {}",
+                    javaVersion,
+                    parentProjectId,
+                )
+            }
+        }
         return try {
             client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME") ?: ""
-        } catch (e: FeignException.NotFound) {
+        } catch (_: FeignException.NotFound) {
             ""
         }
     }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -237,10 +237,14 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         log.info("Set parameter $name value $value for $scope with id $id")
     }
 
-    private fun resolveJavaHome(javaVersion: String?): String =
-        javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
-            ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
-            ?: ""
+    private fun resolveJavaHome(javaVersion: String?): String {
+        javaHomeMapping?.resolveOrNull(javaVersion)?.let { return "%$it%" }
+        return try {
+            client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME") ?: ""
+        } catch (e: FeignException.NotFound) {
+            ""
+        }
+    }
 
     private fun assignProjectAdminRoleToUser(
         projectId: String,

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -238,15 +238,9 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         log.info("Set parameter $name value $value for $scope with id $id")
     }
 
-    /**
-     * Explicit override for [javaVersion]'s major, else [javaHomeMapping]'s leading template,
-     * else whatever `env.JAVA_HOME` is already on [parentProjectId] (empty if that's unset too —
-     * D9 in `set-env-java-home-from-java-version/design.md`, this never returns null).
-     */
     private fun resolveJavaHome(javaVersion: String?): String =
         javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
             ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
-            ?: ""
 
     private fun assignProjectAdminRoleToUser(
         projectId: String,

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -240,6 +240,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
     private fun resolveJavaHome(javaVersion: String?): String =
         javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
             ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
+            ?: ""
 
     private fun assignProjectAdminRoleToUser(
         projectId: String,

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -73,7 +73,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         JAVA_HOME_MAPPING,
         help = "env.JAVA_HOME mapping: a leading bare template (e.g. env.JDK_{major}_0) followed by " +
             "optional major=name overrides (e.g. 8=env.JDK_1_8), comma/semicolon separated",
-    ).convert { JavaHomeMappingOption.parse(it) }
+    ).convert { JavaHomeMappingOption.parse(it, JAVA_HOME_MAPPING) }
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
@@ -111,15 +111,13 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             project.id,
         )
         attachVcsRootToBuildType(compileConfig.id, vcsRootId)
+        // Superseded by env.JAVA_HOME below; kept for teams that still consume it. Remove once
+        // every consumer has migrated to %env.JAVA_HOME% (design.md Decision 11).
         val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
-            setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
+            setParameter(ConfigurationType.BUILD_TYPE, compileConfig.id, "JDK_VERSION", projectJDKVersion)
         }
-        setProjectParameter(
-            project.id,
-            "env.JAVA_HOME",
-            resolveJavaHome(client, parentProjectId, javaHomeMapping, component.buildParameters?.javaVersion),
-        )
+        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome(component.buildParameters?.javaVersion))
         val releaseConfig =
             if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRcForce) {
                 val rcConfig = createBuildConf(
@@ -137,7 +135,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
                     addSnapshotDependency(checklistConfig, rcConfig, DependencyFailureAction.CANCEL)
-                    setBuildTypeParameter(
+                    setParameter(
+                        ConfigurationType.BUILD_TYPE,
                         checklistConfig.id,
                         "BUILD_VERSION",
                         "%dep.${compileConfig.id}.BUILD_VERSION%",
@@ -154,7 +153,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 addSnapshotDependency(rcConfig, compileConfig, DependencyFailureAction.CANCEL)
                 addSnapshotDependency(releaseConfig, rcConfig, DependencyFailureAction.CANCEL)
 
-                setBuildTypeParameter(rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
+                setParameter(ConfigurationType.BUILD_TYPE, rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
                 releaseConfig
             } else {
                 val releaseConfig = createBuildConf(
@@ -167,10 +166,10 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 releaseConfig
             }
         disableBuildStep(releaseConfig.id, "IncrementTeamCityBuildConfigurationParameter")
-        setBuildTypeParameter(releaseConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
-        setBuildTypeParameter(releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
-        setProjectParameter(project.id, "COMPONENT_NAME", componentName)
-        setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)
+        setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
+        setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
+        setParameter(ConfigurationType.PROJECT, project.id, "COMPONENT_NAME", componentName)
+        setParameter(ConfigurationType.PROJECT, project.id, "PROJECT_VERSION", minorVersion)
         (
             listOfNotNull(component.componentOwner) +
                 (component.releaseManager?.split(",") ?: emptyList())
@@ -229,21 +228,25 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         )
     }
 
-    private fun setBuildTypeParameter(
-        buildTypeId: String,
+    private fun setParameter(
+        configurationType: ConfigurationType,
+        id: String,
         name: String,
         value: String,
-    ) = client.setParameter(ConfigurationType.BUILD_TYPE, buildTypeId, name, value).also {
-        log.info("Set parameter $name value $value for build configuration with id $buildTypeId")
+    ) = client.setParameter(configurationType, id, name, value).also {
+        val scope = if (configurationType == ConfigurationType.BUILD_TYPE) "build configuration" else "project"
+        log.info("Set parameter $name value $value for $scope with id $id")
     }
 
-    private fun setProjectParameter(
-        projectId: String,
-        name: String,
-        value: String,
-    ) = client.setParameter(ConfigurationType.PROJECT, projectId, name, value).also {
-        log.info("Set parameter $name value $value for project with id $projectId")
-    }
+    /**
+     * Explicit override for [javaVersion]'s major, else [javaHomeMapping]'s leading template,
+     * else whatever `env.JAVA_HOME` is already on [parentProjectId] (empty if that's unset too —
+     * D9 in `set-env-java-home-from-java-version/design.md`, this never returns null).
+     */
+    private fun resolveJavaHome(javaVersion: String?): String =
+        javaHomeMapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
+            ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
+            ?: ""
 
     private fun assignProjectAdminRoleToUser(
         projectId: String,
@@ -316,13 +319,3 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         const val TEMPLATE_RELEASE = "CDRelease"
     }
 }
-
-private fun resolveJavaHome(
-    client: TeamcityClient,
-    parentProjectId: String,
-    mapping: JavaHomeMappingOption?,
-    javaVersion: String?,
-): String =
-    mapping?.resolveOrNull(javaVersion)?.let { "%$it%" }
-        ?: client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
-        ?: ""

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -111,8 +111,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             project.id,
         )
         attachVcsRootToBuildType(compileConfig.id, vcsRootId)
-        // Superseded by env.JAVA_HOME below; kept for teams that still consume it. Remove once
-        // every consumer has migrated to %env.JAVA_HOME% (design.md Decision 11).
+        // TD-001: superseded by env.JAVA_HOME below; see docs/tech-debt/TD-001-jdk-version-param-removal.md
         val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
             setParameter(ConfigurationType.BUILD_TYPE, compileConfig.id, "JDK_VERSION", projectJDKVersion)

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
@@ -1,17 +1,28 @@
 package org.octopusden.octopus.automation.teamcity.utils.javahome
 
 /**
- * Resolves the `env.JAVA_HOME` reference for a JDK major version, given a caller-supplied [JavaHomeMappingOption].
+ * Resolves the TeamCity parameter name to reference from `env.JAVA_HOME`, given a caller-supplied [JavaHomeMappingOption].
+ * The caller wraps the result in `%...%`.
  */
 object JavaHomeMapping {
     const val PLACEHOLDER = "{major}"
 
+    /** `null` when no JDK major version can be derived from [javaVersion] — the registry does not constrain that field. */
     fun resolve(
         javaVersion: String,
         overrides: Map<Int, String>,
         template: String,
-    ): String {
-        val major = javaVersion.substringAfterLast('.').toInt()
+    ): String? {
+        val major = majorOrNull(javaVersion) ?: return null
         return overrides[major] ?: template.replace(PLACEHOLDER, major.toString())
     }
+
+    /** `1.8` and `1.8.0_292` are the legacy scheme, where the major is the second segment; everything since is the first. */
+    private fun majorOrNull(javaVersion: String): Int? =
+        javaVersion
+            .trim()
+            .removePrefix("1.")
+            .substringBefore('.')
+            .toIntOrNull()
+            ?.takeIf { it > 0 }
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
@@ -1,0 +1,19 @@
+package org.octopusden.octopus.automation.teamcity.utils.javahome
+
+/**
+ * Resolves the `env.JAVA_HOME` reference for a JDK major version, given a caller-supplied
+ * [JavaHomeMappingOption]. Carries no formula or exception of its own (D4 in
+ * `set-env-java-home-from-java-version/design.md`) — every mapping comes from the option.
+ */
+object JavaHomeMapping {
+    const val PLACEHOLDER = "{major}"
+
+    fun resolve(
+        javaVersion: String,
+        overrides: Map<Int, String>,
+        template: String,
+    ): String {
+        val major = javaVersion.substringAfterLast('.').toInt()
+        return overrides[major] ?: template.replace(PLACEHOLDER, major.toString())
+    }
+}

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMapping.kt
@@ -1,9 +1,7 @@
 package org.octopusden.octopus.automation.teamcity.utils.javahome
 
 /**
- * Resolves the `env.JAVA_HOME` reference for a JDK major version, given a caller-supplied
- * [JavaHomeMappingOption]. Carries no formula or exception of its own (D4 in
- * `set-env-java-home-from-java-version/design.md`) — every mapping comes from the option.
+ * Resolves the `env.JAVA_HOME` reference for a JDK major version, given a caller-supplied [JavaHomeMappingOption].
  */
 object JavaHomeMapping {
     const val PLACEHOLDER = "{major}"

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
@@ -22,7 +22,10 @@ data class JavaHomeMappingOption(
         ): JavaHomeMappingOption {
             fun fail(message: String): Nothing = throw BadParameterValue("$optionName: $message")
 
-            val entries = raw.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }
+            val entries = raw.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }
+            if (entries.any { it.isEmpty() }) {
+                fail("mapping entries must not be blank (leading, trailing, or consecutive separators are not allowed)")
+            }
             val template = parseTemplate(entries.firstOrNull(), ::fail)
 
             val overrides = mutableMapOf<Int, String>()

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
@@ -15,19 +15,28 @@ data class JavaHomeMappingOption(
     fun resolveOrNull(javaVersion: String?): String? = javaVersion?.let { JavaHomeMapping.resolve(it, overrides, template) }
 
     companion object {
-        const val OPTION_NAME = "--java-home-mapping"
+        /**
+         * [optionName] is the CLI flag name used only to prefix error messages.
+         */
+        fun parse(
+            raw: String,
+            optionName: String,
+        ): JavaHomeMappingOption {
+            fun fail(message: String): Nothing = throw BadParameterValue("$optionName: $message")
 
-        fun parse(raw: String): JavaHomeMappingOption {
             val entries = raw.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }
-            val template = parseTemplate(entries.firstOrNull())
+            val template = parseTemplate(entries.firstOrNull(), ::fail)
 
             val overrides = mutableMapOf<Int, String>()
-            entries.drop(1).forEach { entry -> parseOverride(entry, overrides) }
+            entries.drop(1).forEach { entry -> parseOverride(entry, overrides, ::fail) }
 
             return JavaHomeMappingOption(overrides, template)
         }
 
-        private fun parseTemplate(candidate: String?): String {
+        private fun parseTemplate(
+            candidate: String?,
+            fail: (String) -> Nothing,
+        ): String {
             val template = candidate?.takeIf { !it.contains('=') }
                 ?: fail("requires a leading template entry (no '=') as its first segment, e.g. env.JDK_{major}_0")
             if (isWrapped(template)) fail("leading template must not already be %-wrapped (got '$template')")
@@ -41,6 +50,7 @@ data class JavaHomeMappingOption(
         private fun parseOverride(
             entry: String,
             overrides: MutableMap<Int, String>,
+            fail: (String) -> Nothing,
         ) {
             if (!entry.contains('=')) fail("a bare entry ('$entry') is only valid as the first segment")
             val key = entry.substringBefore('=').trim()
@@ -56,7 +66,5 @@ data class JavaHomeMappingOption(
         }
 
         private fun isWrapped(value: String) = value.startsWith('%') && value.endsWith('%')
-
-        private fun fail(message: String): Nothing = throw BadParameterValue("$OPTION_NAME: $message")
     }
 }

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
@@ -15,9 +15,7 @@ data class JavaHomeMappingOption(
     fun resolveOrNull(javaVersion: String?): String? = javaVersion?.let { JavaHomeMapping.resolve(it, overrides, template) }
 
     companion object {
-        /**
-         * [optionName] is the CLI flag name used only to prefix error messages.
-         */
+        /** [optionName] is the CLI flag name used only to prefix error messages. */
         fun parse(
             raw: String,
             optionName: String,

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
@@ -1,0 +1,62 @@
+package org.octopusden.octopus.automation.teamcity.utils.javahome
+
+import com.github.ajalt.clikt.core.BadParameterValue
+import org.octopusden.octopus.automation.teamcity.SPLIT_SYMBOLS
+
+/**
+ * Parsed `--java-home-mapping` value: a required leading bare template  plus per-major overrides.
+ * [parse] validates eagerly, before any TeamCity project is created.
+ */
+data class JavaHomeMappingOption(
+    val overrides: Map<Int, String>,
+    val template: String,
+) {
+    /** `null` when [javaVersion] is `null` — there is nothing to resolve without it. */
+    fun resolveOrNull(javaVersion: String?): String? = javaVersion?.let { JavaHomeMapping.resolve(it, overrides, template) }
+
+    companion object {
+        const val OPTION_NAME = "--java-home-mapping"
+
+        fun parse(raw: String): JavaHomeMappingOption {
+            val entries = raw.split(SPLIT_SYMBOLS.toRegex()).map { it.trim() }.filter { it.isNotEmpty() }
+            val template = parseTemplate(entries.firstOrNull())
+
+            val overrides = mutableMapOf<Int, String>()
+            entries.drop(1).forEach { entry -> parseOverride(entry, overrides) }
+
+            return JavaHomeMappingOption(overrides, template)
+        }
+
+        private fun parseTemplate(candidate: String?): String {
+            val template = candidate?.takeIf { !it.contains('=') }
+                ?: fail("requires a leading template entry (no '=') as its first segment, e.g. env.JDK_{major}_0")
+            if (isWrapped(template)) fail("leading template must not already be %-wrapped (got '$template')")
+            val placeholderCount = template.split(JavaHomeMapping.PLACEHOLDER).size - 1
+            if (placeholderCount != 1) {
+                fail("leading template must contain exactly one ${JavaHomeMapping.PLACEHOLDER} occurrence (got '$template')")
+            }
+            return template
+        }
+
+        private fun parseOverride(
+            entry: String,
+            overrides: MutableMap<Int, String>,
+        ) {
+            if (!entry.contains('=')) fail("a bare entry ('$entry') is only valid as the first segment")
+            val key = entry.substringBefore('=').trim()
+            val major = key.toIntOrNull()?.takeIf { it > 0 }
+                ?: fail("'$key' is not a valid JDK major version (from entry '$entry')")
+            val value = entry.substringAfter('=').trim()
+            if (isWrapped(value)) fail("override value must not already be %-wrapped (from entry '$entry')")
+            if (value.contains(JavaHomeMapping.PLACEHOLDER)) {
+                fail("override value must not contain ${JavaHomeMapping.PLACEHOLDER} (from entry '$entry')")
+            }
+            if (overrides.containsKey(major)) fail("duplicate override for major '$major' (from entry '$entry')")
+            overrides[major] = value
+        }
+
+        private fun isWrapped(value: String) = value.startsWith('%') && value.endsWith('%')
+
+        private fun fail(message: String): Nothing = throw BadParameterValue("$OPTION_NAME: $message")
+    }
+}

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/utils/javahome/JavaHomeMappingOption.kt
@@ -4,14 +4,14 @@ import com.github.ajalt.clikt.core.BadParameterValue
 import org.octopusden.octopus.automation.teamcity.SPLIT_SYMBOLS
 
 /**
- * Parsed `--java-home-mapping` value: a required leading bare template  plus per-major overrides.
+ * Parsed `--java-home-mapping` value: a required leading bare template plus per-major overrides.
  * [parse] validates eagerly, before any TeamCity project is created.
  */
 data class JavaHomeMappingOption(
     val overrides: Map<Int, String>,
     val template: String,
 ) {
-    /** `null` when [javaVersion] is `null` — there is nothing to resolve without it. */
+    /** `null` when [javaVersion] is `null`, or when no JDK major version can be derived from it. */
     fun resolveOrNull(javaVersion: String?): String? = javaVersion?.let { JavaHomeMapping.resolve(it, overrides, template) }
 
     companion object {
@@ -55,6 +55,7 @@ data class JavaHomeMappingOption(
             val major = key.toIntOrNull()?.takeIf { it > 0 }
                 ?: fail("'$key' is not a valid JDK major version (from entry '$entry')")
             val value = entry.substringAfter('=').trim()
+            if (value.isBlank()) fail("override value must not be blank (from entry '$entry')")
             if (isWrapped(value)) fail("override value must not already be %-wrapped (from entry '$entry')")
             if (value.contains(JavaHomeMapping.PLACEHOLDER)) {
                 fail("override value must not contain ${JavaHomeMapping.PLACEHOLDER} (from entry '$entry')")

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -637,8 +637,8 @@ class ApplicationTest {
             return teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "env.JAVA_HOME")
         }
 
-        // no mapping, no env.JAVA_HOME on the parent -> written empty, not omitted; inherited by every
-        // build config in the project, not only compile
+        // no mapping, no env.JAVA_HOME on the parent -> written empty, not omitted;
+        // inherited by every build config in the project
         cleanUpResources(teamcityClient, config)
         Assertions.assertEquals("", createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId))
         nonCompileConfigIds.forEach { configId ->

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -651,12 +651,12 @@ class ApplicationTest {
         Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(defaultJDKComponentName, defaultJDKProjectId))
         Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId))
 
-        // mapping supplied, no env.JAVA_HOME on the parent: an override covering the component's major wins;
-        // default-jdk-component has no javaVersion at all, so it still falls back to the (unset) parent
+        // mapping supplied, no env.JAVA_HOME on the parent: an override covering each
+        // component's major wins (default-jdk-component resolves to major 8, custom to 11)
         cleanUpResources(teamcityClient, config)
         val mappingWithOverrides = "env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0"
         Assertions.assertEquals(
-            "",
+            "%env.JDK_1_8%",
             createBuildChainAndGetJavaHome(defaultJDKComponentName, defaultJDKProjectId, mappingWithOverrides),
         )
         Assertions.assertEquals(

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -76,6 +76,7 @@ class ApplicationTest {
         minorVersion: String? = "1.0",
         createChecklist: Boolean = true,
         createRcForce: Boolean = false,
+        javaHomeMapping: String? = null,
     ): Int =
         execute(
             testMethodName,
@@ -87,6 +88,7 @@ class ApplicationTest {
             "${TeamcityCreateBuildChainCommand.CR}=http://$hostComponentsRegistry",
             "${TeamcityCreateBuildChainCommand.CREATE_CHECKLIST}=$createChecklist",
             "${TeamcityCreateBuildChainCommand.CREATE_RC_FORCE}=$createRcForce",
+            *listOfNotNull(javaHomeMapping?.let { "${TeamcityCreateBuildChainCommand.JAVA_HOME_MAPPING}=$it" }).toTypedArray(),
         )
 
     @ParameterizedTest
@@ -600,6 +602,74 @@ class ApplicationTest {
         Assertions.assertEquals(
             "11",
             teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${customJDKProjectId}_10CompileUtAuto", "JDK_VERSION"),
+        )
+    }
+
+    /**
+     * Tests CreateTeamCityBuildChain for resolving and always writing the env.JAVA_HOME project parameter,
+     * based on --java-home-mapping and the component's javaVersion, with a fallback to the parent project's
+     * own env.JAVA_HOME (empty if that's unset too) when the mapping doesn't resolve one.
+     */
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testTeamCityCreateBuildChainForJavaHome(config: TeamcityTestConfiguration) {
+        val teamcityClient = createClient(config)
+
+        val defaultJDKComponentName = "default-jdk-component"
+        val defaultJDKProjectId = "TestTeamcityAutomation_DefaultJdkComponent"
+        val customJDKComponentName = "custom-jdk-component"
+        val customJDKProjectId = "TestTeamcityAutomation_CustomJdkComponent"
+        val nonCompileConfigIds = listOf(
+            "${customJDKProjectId}_20ReleaseCandidateManual",
+            "${customJDKProjectId}_30ReleaseChecklistValidationManual",
+            "${customJDKProjectId}_40ReleaseManual",
+        )
+
+        fun createBuildChainAndGetJavaHome(
+            componentName: String,
+            projectId: String,
+            javaHomeMapping: String? = null,
+        ): String {
+            Assertions.assertEquals(
+                0,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, javaHomeMapping = javaHomeMapping),
+            )
+            return teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "env.JAVA_HOME")
+        }
+
+        // no mapping, no env.JAVA_HOME on the parent -> written empty, not omitted; inherited by every
+        // build config in the project, not only compile
+        cleanUpResources(teamcityClient, config)
+        Assertions.assertEquals("", createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId))
+        nonCompileConfigIds.forEach { configId ->
+            Assertions.assertEquals("", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, configId, "env.JAVA_HOME"))
+        }
+
+        // no mapping, parent has env.JAVA_HOME -> inherited as-is, regardless of the component's javaVersion
+        cleanUpResources(teamcityClient, config)
+        teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
+        Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(defaultJDKComponentName, defaultJDKProjectId))
+        Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId))
+
+        // mapping supplied, no env.JAVA_HOME on the parent: an override covering the component's major wins;
+        // default-jdk-component has no javaVersion at all, so it still falls back to the (unset) parent
+        cleanUpResources(teamcityClient, config)
+        val mappingWithOverrides = "env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0"
+        Assertions.assertEquals(
+            "",
+            createBuildChainAndGetJavaHome(defaultJDKComponentName, defaultJDKProjectId, mappingWithOverrides),
+        )
+        Assertions.assertEquals(
+            "%env.JDK_11_0%",
+            createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId, mappingWithOverrides),
+        )
+
+        // mapping supplied but no override covers the component's major -> the leading template applies
+        cleanUpResources(teamcityClient, config)
+        val mappingWithoutOverrideFor11 = "env.JDK_{major}_0,8=env.JDK_1_8"
+        Assertions.assertEquals(
+            "%env.JDK_11_0%",
+            createBuildChainAndGetJavaHome(customJDKComponentName, customJDKProjectId, mappingWithoutOverrideFor11),
         )
     }
 

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
@@ -126,4 +126,28 @@ class JavaHomeMappingOptionTest {
         }
         assertTrue(ex.message!!.contains("%env.JDK_{major}_0%"))
     }
+
+    @Test
+    fun `a leading separator is rejected, not silently skipped to reach the template`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse(",env.JDK_{major}_0,8=env.JDK_1_8", OPTION_NAME)
+        }
+        assertTrue(ex.message!!.contains("blank"))
+    }
+
+    @Test
+    fun `a trailing separator is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,", OPTION_NAME)
+        }
+        assertTrue(ex.message!!.contains("blank"))
+    }
+
+    @Test
+    fun `consecutive separators are rejected, not silently collapsed`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,,8=env.JDK_1_8", OPTION_NAME)
+        }
+        assertTrue(ex.message!!.contains("blank"))
+    }
 }

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
@@ -1,0 +1,112 @@
+package utils.javahome
+
+import com.github.ajalt.clikt.core.BadParameterValue
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.automation.teamcity.utils.javahome.JavaHomeMappingOption
+
+class JavaHomeMappingOptionTest {
+    @Test
+    fun `resolveOrNull resolves against a non-null javaVersion`() {
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,11=env.JDK_11_0")
+
+        assertEquals("env.JDK_11_0", option.resolveOrNull("11"))
+        assertEquals("env.JDK_17_0", option.resolveOrNull("17"))
+    }
+
+    @Test
+    fun `resolveOrNull returns null for a null javaVersion`() {
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0")
+
+        assertEquals(null, option.resolveOrNull(null))
+    }
+
+    @Test
+    fun `valid mapping with a leading template and overrides is parsed`() {
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0")
+
+        assertEquals("env.JDK_{major}_0", option.template)
+        assertEquals(mapOf(8 to "env.JDK_1_8", 11 to "env.JDK_11_0"), option.overrides)
+    }
+
+    @Test
+    fun `mapping with only overrides, no leading template, is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("8=env.JDK_1_8,11=env.JDK_11_0")
+        }
+        assertTrue(ex.message!!.contains("leading"))
+    }
+
+    @Test
+    fun `a bare entry not in the first position is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("8=env.JDK_1_8,env.JDK_{major}_0")
+        }
+        assertTrue(ex.message!!.contains("first segment"))
+    }
+
+    @Test
+    fun `override value without an env prefix is accepted`() {
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=JDK_1_8")
+
+        assertEquals(mapOf(8 to "JDK_1_8"), option.overrides)
+    }
+
+    @Test
+    fun `non-numeric override key is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,abc=env.JDK_1_8")
+        }
+        assertTrue(ex.message!!.contains("abc"))
+    }
+
+    @Test
+    fun `already-wrapped override value is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=%env.JDK_1_8%")
+        }
+        assertTrue(ex.message!!.contains("8=%env.JDK_1_8%"))
+    }
+
+    @Test
+    fun `override value containing the placeholder is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_{major}_8")
+        }
+        assertTrue(ex.message!!.contains("8=env.JDK_{major}_8"))
+    }
+
+    @Test
+    fun `duplicate override key is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0")
+        }
+        assertTrue(ex.message!!.contains("8"))
+    }
+
+    @Test
+    fun `leading template without the placeholder is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_HOME,8=env.JDK_1_8")
+        }
+        assertTrue(ex.message!!.contains("env.JDK_HOME"))
+    }
+
+    @Test
+    fun `leading template with more than one placeholder is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_{major}")
+        }
+        assertTrue(ex.message!!.contains("env.JDK_{major}_{major}"))
+    }
+
+    @Test
+    fun `already-wrapped leading template is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("%env.JDK_{major}_0%,8=env.JDK_1_8")
+        }
+        assertTrue(ex.message!!.contains("%env.JDK_{major}_0%"))
+    }
+}

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.octopusden.octopus.automation.teamcity.utils.javahome.JavaHomeMappingOption
 
+private const val OPTION_NAME = "--java-home-mapping"
+
 class JavaHomeMappingOptionTest {
     @Test
     fun `resolveOrNull resolves against a non-null javaVersion`() {
-        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,11=env.JDK_11_0")
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,11=env.JDK_11_0", OPTION_NAME)
 
         assertEquals("env.JDK_11_0", option.resolveOrNull("11"))
         assertEquals("env.JDK_17_0", option.resolveOrNull("17"))
@@ -18,14 +20,14 @@ class JavaHomeMappingOptionTest {
 
     @Test
     fun `resolveOrNull returns null for a null javaVersion`() {
-        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0")
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0", OPTION_NAME)
 
         assertEquals(null, option.resolveOrNull(null))
     }
 
     @Test
     fun `valid mapping with a leading template and overrides is parsed`() {
-        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0")
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0", OPTION_NAME)
 
         assertEquals("env.JDK_{major}_0", option.template)
         assertEquals(mapOf(8 to "env.JDK_1_8", 11 to "env.JDK_11_0"), option.overrides)
@@ -34,7 +36,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `mapping with only overrides, no leading template, is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("8=env.JDK_1_8,11=env.JDK_11_0")
+            JavaHomeMappingOption.parse("8=env.JDK_1_8,11=env.JDK_11_0", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("leading"))
     }
@@ -42,14 +44,14 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `a bare entry not in the first position is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("8=env.JDK_1_8,env.JDK_{major}_0")
+            JavaHomeMappingOption.parse("8=env.JDK_1_8,env.JDK_{major}_0", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("first segment"))
     }
 
     @Test
     fun `override value without an env prefix is accepted`() {
-        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=JDK_1_8")
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=JDK_1_8", OPTION_NAME)
 
         assertEquals(mapOf(8 to "JDK_1_8"), option.overrides)
     }
@@ -57,7 +59,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `non-numeric override key is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_{major}_0,abc=env.JDK_1_8")
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,abc=env.JDK_1_8", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("abc"))
     }
@@ -65,7 +67,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `already-wrapped override value is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=%env.JDK_1_8%")
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=%env.JDK_1_8%", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("8=%env.JDK_1_8%"))
     }
@@ -73,7 +75,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `override value containing the placeholder is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_{major}_8")
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_{major}_8", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("8=env.JDK_{major}_8"))
     }
@@ -81,7 +83,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `duplicate override key is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0")
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,8=env.JDK_8_0", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("8"))
     }
@@ -89,7 +91,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `leading template without the placeholder is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_HOME,8=env.JDK_1_8")
+            JavaHomeMappingOption.parse("env.JDK_HOME,8=env.JDK_1_8", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("env.JDK_HOME"))
     }
@@ -97,7 +99,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `leading template with more than one placeholder is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("env.JDK_{major}_{major}")
+            JavaHomeMappingOption.parse("env.JDK_{major}_{major}", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("env.JDK_{major}_{major}"))
     }
@@ -105,7 +107,7 @@ class JavaHomeMappingOptionTest {
     @Test
     fun `already-wrapped leading template is rejected`() {
         val ex = assertThrows(BadParameterValue::class.java) {
-            JavaHomeMappingOption.parse("%env.JDK_{major}_0%,8=env.JDK_1_8")
+            JavaHomeMappingOption.parse("%env.JDK_{major}_0%,8=env.JDK_1_8", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("%env.JDK_{major}_0%"))
     }

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingOptionTest.kt
@@ -26,6 +26,13 @@ class JavaHomeMappingOptionTest {
     }
 
     @Test
+    fun `resolveOrNull returns null for a javaVersion with no derivable major`() {
+        val option = JavaHomeMappingOption.parse("env.JDK_{major}_0", OPTION_NAME)
+
+        assertEquals(null, option.resolveOrNull("<value>"))
+    }
+
+    @Test
     fun `valid mapping with a leading template and overrides is parsed`() {
         val option = JavaHomeMappingOption.parse("env.JDK_{major}_0,8=env.JDK_1_8,11=env.JDK_11_0", OPTION_NAME)
 
@@ -70,6 +77,14 @@ class JavaHomeMappingOptionTest {
             JavaHomeMappingOption.parse("env.JDK_{major}_0,8=%env.JDK_1_8%", OPTION_NAME)
         }
         assertTrue(ex.message!!.contains("8=%env.JDK_1_8%"))
+    }
+
+    @Test
+    fun `blank override value is rejected`() {
+        val ex = assertThrows(BadParameterValue::class.java) {
+            JavaHomeMappingOption.parse("env.JDK_{major}_0,8=", OPTION_NAME)
+        }
+        assertTrue(ex.message!!.contains("8="))
     }
 
     @Test

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt
@@ -1,6 +1,7 @@
 package utils.javahome
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import org.octopusden.octopus.automation.teamcity.utils.javahome.JavaHomeMapping
 
@@ -58,5 +59,31 @@ class JavaHomeMappingTest {
             "JDK_1_8",
             JavaHomeMapping.resolve("1.8", mapOf(8 to "JDK_1_8"), "env.JDK_{major}_0"),
         )
+    }
+
+    @Test
+    fun `a modern multi-segment version resolves to its leading segment`() {
+        assertEquals(
+            "env.JDK_21_0",
+            JavaHomeMapping.resolve("21.0.1", emptyMap(), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `a legacy multi-segment version resolves to its second segment`() {
+        assertEquals(
+            "env.JDK_8_0",
+            JavaHomeMapping.resolve("1.8.0_292", emptyMap(), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `a version with no derivable major resolves to null`() {
+        listOf("   ", "<value>", "999999999999999999999", "0", "17-ea").forEach { javaVersion ->
+            assertNull(
+                JavaHomeMapping.resolve(javaVersion, mapOf(8 to "env.JDK_1_8"), "env.JDK_{major}_0"),
+                "expected no major for '$javaVersion'",
+            )
+        }
     }
 }

--- a/src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt
+++ b/src/test/kotlin/utils/javahome/JavaHomeMappingTest.kt
@@ -1,0 +1,62 @@
+package utils.javahome
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.octopusden.octopus.automation.teamcity.utils.javahome.JavaHomeMapping
+
+class JavaHomeMappingTest {
+    @Test
+    fun `explicit override for the resolved major wins over the template`() {
+        assertEquals(
+            "env.JDK_17_CUSTOM",
+            JavaHomeMapping.resolve("17", mapOf(17 to "env.JDK_17_CUSTOM"), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `major with no override substitutes into the template`() {
+        assertEquals(
+            "env.JDK_17_0",
+            JavaHomeMapping.resolve("17", mapOf(11 to "env.JDK_11_0"), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `an unlisted future major resolves via the template without a code change`() {
+        assertEquals(
+            "env.JDK_27_0",
+            JavaHomeMapping.resolve("27", mapOf(11 to "env.JDK_11_0"), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `major 8 substitutes into the template when not overridden, no built-in exception`() {
+        assertEquals(
+            "env.JDK_8_0",
+            JavaHomeMapping.resolve("1.8", emptyMap(), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `caller-supplied override reproduces the historical major-8 naming only when supplied`() {
+        assertEquals(
+            "env.JDK_1_8",
+            JavaHomeMapping.resolve("1.8", mapOf(8 to "env.JDK_1_8"), "env.JDK_{major}_0"),
+        )
+    }
+
+    @Test
+    fun `an override keyed by the derived major matches both dotted and bare source forms`() {
+        val overrides = mapOf(8 to "env.JDK_1_8")
+        assertEquals("env.JDK_1_8", JavaHomeMapping.resolve("1.8", overrides, "env.JDK_{major}_0"))
+        assertEquals("env.JDK_1_8", JavaHomeMapping.resolve("8", overrides, "env.JDK_{major}_0"))
+    }
+
+    @Test
+    fun `override value without an env prefix is used as-is`() {
+        assertEquals(
+            "JDK_1_8",
+            JavaHomeMapping.resolve("1.8", mapOf(8 to "JDK_1_8"), "env.JDK_{major}_0"),
+        )
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring `env.JAVA_HOME` when creating build chains.
  * Added Java-version-based mappings with per-major overrides and fallback templates.
  * Supports parent-project inheritance or an empty value when no mapping is available.
  * Added validation and warnings for invalid mapping or Java-version values.

* **Documentation**
  * Documented configuration behavior, migration considerations, and deprecation of the existing JDK version parameter.

* **Tests**
  * Added coverage for parsing, resolution, validation, overrides, inheritance, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Upgrade Notes
- New optional parameter, `JAVA_HOME_MAPPING`, for `env.JAVA_HOME` mapping: a leading template (e.g. `env.JDK_{major}_0`) plus optional major=name overrides, comma/semicolon separated. Leave empty to skip mapping.
- This changes always set `env.JAVA_HOME` parameter on each created TeamCity project. Default to parent project's `env.JAVA_HOME` or empty.