### PR TITLE
env.JAVA_HOME default parameter

### DIFF
--- a/docs/tech-debt/TD-001-jdk-version-param-removal.md
+++ b/docs/tech-debt/TD-001-jdk-version-param-removal.md
@@ -1,0 +1,43 @@
+# TD-001: Remove the `JDK_VERSION` build-type parameter from `create-build-chain`
+
+## Status
+
+Open.
+
+## Context
+
+`TeamcityCreateBuildChainCommand.createBuildChain()` sets a `JDK_VERSION` build-type parameter
+on the compile build config only, derived from the component-registry's `javaVersion` field
+(e.g. `"1.8"`, `"11"`). It's a bare version string, useful only if a build template downstream
+knows how to turn it into a JDK path.
+
+The same command now also resolves and always writes an `env.JAVA_HOME` **project**-level
+parameter — a proper TeamCity parameter reference (e.g. `%env.JDK_17_0%`), from the optional
+`--default-java-home` CLI option or, failing that, the parent project's own `env.JAVA_HOME` —
+inherited by every build config in the chain, not just compile. `JDK_VERSION` is kept only so
+teams still consuming it don't break; both parameters are set side by side for now.
+
+## Symptoms (when this will hurt)
+
+- Every `create-build-chain` run resolves and writes two parameters for one concept ("which JDK
+  to use") once all consumers have migrated to `env.JAVA_HOME`.
+- A future contributor may treat `JDK_VERSION` as load-bearing and build on top of it, deepening
+  the duplication this item exists to remove.
+
+## Acceptance criteria
+
+1. Confirm no build template still reads `%JDK_VERSION%` — all consume `%env.JAVA_HOME%`.
+2. Remove the `JDK_VERSION`-setting block in
+   `TeamcityCreateBuildChainCommand.kt::createBuildChain`.
+3. Remove or update `ApplicationTest.kt::testTeamCityCreateBuildChainForJDKVersion`.
+
+No specific date — this is consumer-migration-gated, not time-gated.
+
+## Related
+
+- `src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt` —
+  both parameters are set in `createBuildChain`.
+- `src/test/kotlin/ApplicationTest.kt::testTeamCityCreateBuildChainForJDKVersion` — current
+  coverage of the parameter being removed.
+- `src/test/kotlin/ApplicationTest.kt::testTeamCityCreateBuildChainForJavaHome` — coverage of the
+  `env.JAVA_HOME` parameter this item leaves as the sole survivor.

--- a/metarunners/CreateTeamCityBuildChain.xml
+++ b/metarunners/CreateTeamCityBuildChain.xml
@@ -8,11 +8,12 @@
             <param name="MINOR_VERSION" value="%MINOR_VERSION%" />
             <param name="CREATE_CHECKLIST" value="%CREATE_CHECKLIST%" />
             <param name="CREATE_RC_FORCE" value="%CREATE_RC_FORCE%" />
+            <param name="DEFAULT_JAVA_HOME" value="" spec="text description='Optional bare TeamCity parameter reference for env.JAVA_HOME (e.g. env.JDK_17_0), not %-wrapped. Leave empty to fall back to the parent project env.JAVA_HOME.' display='normal'" />
         </parameters>
         <build-runners>
             <runner name="create build chain" type="OctopusTeamcityAutomation">
                 <parameters>
-                    <param name="ARGS" value="--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% create-build-chain --registry-url=%COMPONENT_REGISTRY_URL% --parent-project-id=%TEAMCITY_PARENT_PROJECT_ID% --component=%COMPONENT_NAME% --minor-version=%MINOR_VERSION% --create-checklist=%CREATE_CHECKLIST% --create-rc-force=%CREATE_RC_FORCE% " />
+                    <param name="ARGS" value="--url=%TEAMCITY_URL% --user=%TEAMCITY_USER% --password=%TEAMCITY_PASSWORD% create-build-chain --registry-url=%COMPONENT_REGISTRY_URL% --parent-project-id=%TEAMCITY_PARENT_PROJECT_ID% --component=%COMPONENT_NAME% --minor-version=%MINOR_VERSION% --create-checklist=%CREATE_CHECKLIST% --create-rc-force=%CREATE_RC_FORCE% --default-java-home=%DEFAULT_JAVA_HOME% " />
                 </parameters>
             </runner>
         </build-runners>

--- a/openspec/changes/set-env-java-home-default-param/design.md
+++ b/openspec/changes/set-env-java-home-default-param/design.md
@@ -8,10 +8,13 @@
   `component.buildParameters?.javaVersion`, falling back to nothing (just skips the write) when it
   matches the parent's `JDK_VERSION` default. `env.JAVA_HOME` does not exist anywhere in this
   command today (on `main`).
-- `setBuildTypeParameter` / `setProjectParameter` (lines 220–234) are the two existing
-  parameter-writing helpers, at build-type and project scope respectively. This change reuses
-  `setProjectParameter` as-is — no need to merge them into one, since this change adds no new
-  build-type-level call sites.
+- `setBuildTypeParameter` / `setProjectParameter` (lines 220–234) were the two existing
+  parameter-writing helpers, at build-type and project scope respectively. Adding `defaultJavaHome`
+  and `resolveJavaHome` alongside them pushed `TeamcityCreateBuildChainCommand` to 12 functions,
+  past detekt's default `TooManyFunctions` threshold of 11. They are now a single
+  `setParameter(configurationType: ConfigurationType, id: String, name: String, value: String)`,
+  used by every call site including the pre-existing `JDK_VERSION` one — the same fix the
+  `env-java-home` branch's more complex approach already applied for the same reason.
 - `client.getParameter(ConfigurationType, id, name)` throws `feign.FeignException.NotFound` (not
   `null`) when the parameter doesn't exist — already handled this way for the `JDK_VERSION`
   parent-default lookup at line 107, and reused identically here.

--- a/openspec/changes/set-env-java-home-default-param/design.md
+++ b/openspec/changes/set-env-java-home-default-param/design.md
@@ -43,7 +43,7 @@ Given `parentProjectId = "TeamOctopus"`:
 **Non-Goals:**
 - No per-major-version mapping, template, or derivation from the component registry — that is the
   `env-java-home` branch's approach, superseded by this one.
-- No change to `JDK_VERSION`.
+- No change to `JDK_VERSION`'s own logic (it is only marked deprecated — see Decision 7).
 - No validation that the supplied reference name resolves to a real agent parameter.
 
 ## Decisions
@@ -85,9 +85,9 @@ Given `parentProjectId = "TeamOctopus"`:
 
 ### 5. `env.JAVA_HOME` is always written: option, else parent, else empty string
 
-- `setProjectParameter(project.id, "env.JAVA_HOME", resolveJavaHome())` is called exactly once per
-  `createBuildChain` run, unconditionally — mirroring `COMPONENT_NAME` and `PROJECT_VERSION`,
-  which are also always set.
+- `setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome())` is
+  called exactly once per `createBuildChain` run, unconditionally — mirroring `COMPONENT_NAME` and
+  `PROJECT_VERSION`, which are also always set.
 - Never skipped, never left absent: an empty string is still an explicit write, so every project
   this tool creates is uniformly editable in TeamCity's UI afterward.
 
@@ -97,12 +97,27 @@ Given `parentProjectId = "TeamOctopus"`:
   RC, checklist, and release build configs all inherit it through normal TeamCity parameter
   inheritance, without a separate build-type-level write for each.
 
+### 7. `JDK_VERSION` is marked deprecated, not removed, tracked as `TD-001`
+
+- `JDK_VERSION` keeps being set exactly as before, on the compile build-type only, from
+  `component.buildParameters?.javaVersion`. Both parameters are written side by side during a
+  migration period, so nothing currently reading `JDK_VERSION` breaks.
+- The removal condition — every consumer migrated to reading `%env.JAVA_HOME%` instead of
+  `%JDK_VERSION%` — is tracked in
+  [`docs/tech-debt/TD-001-jdk-version-param-removal.md`](../../../docs/tech-debt/TD-001-jdk-version-param-removal.md)
+  rather than only here, so it stays discoverable once this change folder is archived. A
+  `TD-001:` comment on the `JDK_VERSION`-setting block in `TeamcityCreateBuildChainCommand.kt`
+  points at the same file.
+- No specific date — consumer-migration-gated, not time-gated, matching the equivalent decision on
+  the `env-java-home` branch.
+
 ## Out of Scope
 
 - Anything derived from `component.buildParameters?.javaVersion` — this change does not read that
-  field at all.
+  field at all beyond the pre-existing, untouched `JDK_VERSION` block.
 - A per-major mapping or template mechanism — see Decision 1.
-- Any change to `JDK_VERSION` or a deprecation note for it.
+- Any change to `JDK_VERSION`'s own computation or scope (Decision 7) — deferred until consumer
+  migration is confirmed via `TD-001`.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/set-env-java-home-default-param/design.md
+++ b/openspec/changes/set-env-java-home-default-param/design.md
@@ -1,0 +1,116 @@
+# Design
+
+## Context
+
+- `TeamcityCreateBuildChainCommand.createBuildChain()`
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`)
+  currently sets `JDK_VERSION` on the compile build-type from
+  `component.buildParameters?.javaVersion`, falling back to nothing (just skips the write) when it
+  matches the parent's `JDK_VERSION` default. `env.JAVA_HOME` does not exist anywhere in this
+  command today (on `main`).
+- `setBuildTypeParameter` / `setProjectParameter` (lines 220–234) are the two existing
+  parameter-writing helpers, at build-type and project scope respectively. This change reuses
+  `setProjectParameter` as-is — no need to merge them into one, since this change adds no new
+  build-type-level call sites.
+- `client.getParameter(ConfigurationType, id, name)` throws `feign.FeignException.NotFound` (not
+  `null`) when the parameter doesn't exist — already handled this way for the `JDK_VERSION`
+  parent-default lookup at line 107, and reused identically here.
+
+## Worked example
+
+Given `parentProjectId = "TeamOctopus"`:
+
+| Invocation | Parent's `env.JAVA_HOME` | Result |
+|---|---|---|
+| `--default-java-home=env.JDK_17_0` | *(irrelevant)* | `env.JAVA_HOME = "%env.JDK_17_0%"` |
+| no `--default-java-home` | `"%env.JDK_1_8%"` | `env.JAVA_HOME = "%env.JDK_1_8%"` (used as-is) |
+| no `--default-java-home` | *(unset)* | `env.JAVA_HOME = ""` |
+| `--default-java-home=%env.JDK_17_0%` (already wrapped) | *(irrelevant)* | **invalid** — command fails before creating any project |
+| `--default-java-home=` (blank) | `"%env.JDK_1_8%"` | treated as omitted → `env.JAVA_HOME = "%env.JDK_1_8%"` |
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every component project this tool creates ends up with its own `env.JAVA_HOME` project
+  parameter — present in TeamCity, directly editable, even if empty.
+- A caller can point a single `create-build-chain` invocation at a specific agent-side JDK
+  parameter without touching the parent project's configuration.
+- Metarunner-driven callers that don't pass the new parameter at all keep working unchanged.
+
+**Non-Goals:**
+- No per-major-version mapping, template, or derivation from the component registry — that is the
+  `env-java-home` branch's approach, superseded by this one.
+- No change to `JDK_VERSION`.
+- No validation that the supplied reference name resolves to a real agent parameter.
+
+## Decisions
+
+### 1. One flat optional value, not a mapping
+
+- `--default-java-home` takes a single string, not a delimited list of entries. There is no
+  per-major-version resolution and no template placeholder — the caller already knows, at the
+  point they invoke `create-build-chain`, which JDK parameter this component's chain should
+  default to (or they omit it and accept the parent's existing default).
+- This intentionally does not scale to "different JDK per component major version" the way the
+  `env-java-home`-branch mapping did — that flexibility is not needed for the common case, and the
+  parent-project fallback already covers "most projects under this parent use JDK X."
+
+### 2. Value is supplied bare; the tool applies `%`-wrapping
+
+- Consistent with `%dep.<id>.BUILD_VERSION%`-style references already written elsewhere in this
+  file — a TeamCity parameter reference is always `%name%` on the wire, but callers configuring
+  metarunner parameters and CLI flags find a bare name (`env.JDK_17_0`) easier to author and
+  reason about than an already-`%`-wrapped one.
+- An already-`%`-wrapped input is rejected outright (`BadParameterValue`), rather than silently
+  accepted or double-wrapped — the same defensive check the more complex approach used for its
+  template/override values.
+
+### 3. Omitting the option is a first-class case, not a degraded one
+
+- `--default-java-home` has no `.required()`, and a blank value (`""`, whitespace) is treated
+  identically to "not supplied" — this is what lets
+  `metarunners/CreateTeamCityBuildChain.xml` default `%DEFAULT_JAVA_HOME%` to `""` and pass it
+  through unconditionally without breaking every existing build config that doesn't set it.
+
+### 4. Fallback is the parent project's existing `env.JAVA_HOME`, used as-is
+
+- When the option is absent, `client.getParameter(ConfigurationType.PROJECT, parentProjectId,
+  "env.JAVA_HOME")` is read and used **without** re-wrapping — whatever is already stored there
+  (typically itself a `%...%` reference, or empty) is copied onto the new project verbatim.
+- `FeignException.NotFound` (no such parameter on the parent) is caught and treated as absent,
+  falling through to Decision 5.
+
+### 5. `env.JAVA_HOME` is always written: option, else parent, else empty string
+
+- `setProjectParameter(project.id, "env.JAVA_HOME", resolveJavaHome())` is called exactly once per
+  `createBuildChain` run, unconditionally — mirroring `COMPONENT_NAME` and `PROJECT_VERSION`,
+  which are also always set.
+- Never skipped, never left absent: an empty string is still an explicit write, so every project
+  this tool creates is uniformly editable in TeamCity's UI afterward.
+
+### 6. Written at project level, inherited by every build config
+
+- Same placement decision as the more complex approach: setting it on `project.id` means compile,
+  RC, checklist, and release build configs all inherit it through normal TeamCity parameter
+  inheritance, without a separate build-type-level write for each.
+
+## Out of Scope
+
+- Anything derived from `component.buildParameters?.javaVersion` — this change does not read that
+  field at all.
+- A per-major mapping or template mechanism — see Decision 1.
+- Any change to `JDK_VERSION` or a deprecation note for it.
+
+## Risks / Trade-offs
+
+- **Silent overwrite of an existing `env.JAVA_HOME`, possibly with an empty string** — same
+  trade-off the more complex approach accepted: if a component project already has its own
+  hand-configured `env.JAVA_HOME`, a re-run of `create-build-chain` without `--default-java-home`
+  overwrites it with the parent's value (or blanks it). Accepted for the same reason: this write
+  happens at project-creation time for a project this tool itself just created; re-running against
+  an existing project is not this command's documented use case.
+- **One value per invocation, not per component major version** — a parent project whose
+  components span multiple JDK majors cannot get an automatically-differentiated `env.JAVA_HOME`
+  per component from this option alone; the caller must either pass a different
+  `--default-java-home` per invocation or manage that difference outside this tool. Accepted as
+  the direct consequence of simplifying away the mapping/template mechanism.

--- a/openspec/changes/set-env-java-home-default-param/design.md
+++ b/openspec/changes/set-env-java-home-default-param/design.md
@@ -28,7 +28,7 @@ Given `parentProjectId = "TeamOctopus"`:
 | `--default-java-home=env.JDK_17_0` | *(irrelevant)* | `env.JAVA_HOME = "%env.JDK_17_0%"` |
 | no `--default-java-home` | `"%env.JDK_1_8%"` | `env.JAVA_HOME = "%env.JDK_1_8%"` (used as-is) |
 | no `--default-java-home` | *(unset)* | `env.JAVA_HOME = ""` |
-| `--default-java-home=%env.JDK_17_0%` (already wrapped) | *(irrelevant)* | **invalid** — command fails before creating any project |
+| `--default-java-home=%env.JDK_17_0%` (or any value containing `%`) | *(irrelevant)* | **invalid** — command fails before creating any project |
 | `--default-java-home=` (blank) | `"%env.JDK_1_8%"` | treated as omitted → `env.JAVA_HOME = "%env.JDK_1_8%"` |
 
 ## Goals / Non-Goals
@@ -64,9 +64,11 @@ Given `parentProjectId = "TeamOctopus"`:
   file — a TeamCity parameter reference is always `%name%` on the wire, but callers configuring
   metarunner parameters and CLI flags find a bare name (`env.JDK_17_0`) easier to author and
   reason about than an already-`%`-wrapped one.
-- An already-`%`-wrapped input is rejected outright (`BadParameterValue`), rather than silently
-  accepted or double-wrapped — the same defensive check the more complex approach used for its
-  template/override values.
+- Any input containing `%` is rejected outright (`BadParameterValue`, naming the value), rather
+  than silently accepted or double-wrapped — the same defensive check the more complex approach
+  used for its template/override values. The check is on `%` anywhere rather than on a fully
+  wrapped value: `%env.JDK_17_0` produces `%%env.JDK_17_0%`, which TeamCity reads as an escaped
+  literal, and the resulting chain fails opaquely at build time instead of at parse time.
 
 ### 3. Omitting the option is a first-class case, not a degraded one
 

--- a/openspec/changes/set-env-java-home-default-param/proposal.md
+++ b/openspec/changes/set-env-java-home-default-param/proposal.md
@@ -49,7 +49,9 @@ deprecation note for it (that was specific to the other approach's rationale, no
 - `TeamcityCreateBuildChainCommand`
   (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
   one new nullable CLI option, one new small `resolveJavaHome` private member, one new
-  project-level `setProjectParameter` call.
+  project-level parameter write. The two pre-existing parameter-writing helpers,
+  `setBuildTypeParameter` and `setProjectParameter`, are merged into one
+  `setParameter(configurationType, id, name, value)` — see `design.md` Context.
 - `metarunners/CreateTeamCityBuildChain.xml`: a new `%DEFAULT_JAVA_HOME%` metarunner parameter,
   defaulting to `""`, passed through as `--default-java-home=%DEFAULT_JAVA_HOME%` so every
   existing build config using this metarunner keeps working unchanged.

--- a/openspec/changes/set-env-java-home-default-param/proposal.md
+++ b/openspec/changes/set-env-java-home-default-param/proposal.md
@@ -1,0 +1,75 @@
+# Proposal
+
+## Why
+
+- A separate, more elaborate approach to the same problem already exists on the `env-java-home`
+  branch (`openspec/changes/set-env-java-home-from-java-version` there): it derives `env.JAVA_HOME`
+  from the component-registry's `javaVersion` field via a caller-supplied `--java-home-mapping`
+  option — a required leading template plus per-major-version overrides, its own placeholder
+  syntax, eager structural validation, and a `JDK_VERSION` deprecation note. That's more machinery
+  than the problem needs.
+- What's actually wanted is simpler: every project this tool creates should end up with an
+  `env.JAVA_HOME` project parameter, and the caller should be able to just say which agent-side
+  JDK parameter a given `create-build-chain` invocation should point at — no per-major derivation,
+  no template, no dependency on the component registry's `javaVersion` field at all.
+- This change starts fresh from `main` (not from `env-java-home`) and replaces that entire
+  approach with a single optional parameter.
+
+## What Changes
+
+**A new `--default-java-home` option on `create-build-chain`:**
+- Value is a **bare TeamCity parameter reference name** (not `%`-wrapped), e.g. `env.JDK_17_0` —
+  the name of a configuration parameter that already exists somewhere in the TeamCity parameter
+  hierarchy (typically published by an agent), not a literal path.
+- **Optional** — omitting it entirely is a supported, unremarkable case (see fallback below).
+- If supplied non-blank, it is wrapped as `%<value>%` when written.
+- Rejected at parse time if already `%`-wrapped — the tool does the wrapping; a caller passing an
+  already-wrapped value almost certainly misunderstands the option.
+
+**Resolution, in order:**
+1. `--default-java-home`, if supplied (non-blank) → `%<value>%`.
+2. Otherwise, the parent project's (`parentProjectId`) existing `env.JAVA_HOME` project
+   parameter, read as-is (no re-wrapping — whatever is already stored there).
+3. Otherwise (parent has no `env.JAVA_HOME` either), an **empty string**.
+
+**Unrelated to the component registry:** unlike the `env-java-home`-branch approach, this does
+not read `component.buildParameters?.javaVersion` at all. Resolution depends only on
+`--default-java-home` and the parent project's existing parameter.
+
+**Where it's written:** as a **project-level** parameter on the newly created component project
+(`project.id`), unconditionally — even when the resolved value is `""` — so every build config
+under that project (compile, RC, checklist, release) inherits it through normal TeamCity
+parameter inheritance.
+
+**No change to `JDK_VERSION`:** its existing logic is untouched; this change does not add a
+deprecation note for it (that was specific to the other approach's rationale, not this one's).
+
+## Affected areas
+
+- `TeamcityCreateBuildChainCommand`
+  (`src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt`):
+  one new nullable CLI option, one new small `resolveJavaHome` private member, one new
+  project-level `setProjectParameter` call.
+- `metarunners/CreateTeamCityBuildChain.xml`: a new `%DEFAULT_JAVA_HOME%` metarunner parameter,
+  defaulting to `""`, passed through as `--default-java-home=%DEFAULT_JAVA_HOME%` so every
+  existing build config using this metarunner keeps working unchanged.
+- **Behavior change for existing consumers**: any TeamCity project under this tool's management
+  whose component project already has its own `env.JAVA_HOME` set will have it overwritten the
+  next time `create-build-chain` runs for that component without `--default-java-home` — with the
+  parent's value, or blanked to `""` if the parent has none either. Teams wanting a stable default
+  should set `env.JAVA_HOME` on the *parent* project, or pass `--default-java-home` explicitly.
+
+## Out of scope
+
+- Deriving anything from the component registry's `javaVersion` field.
+- Per-major-version overrides or a `{major}`-style template — this option is a single flat value
+  per invocation, not a mapping.
+- Any change to `JDK_VERSION`'s own logic, or a deprecation note referencing it.
+- Validating that the supplied parameter name corresponds to a real agent-side TeamCity
+  parameter — this tool has no visibility into agent configuration.
+
+## Rollout note
+
+`--default-java-home` is optional. Omitting it is not an error: `env.JAVA_HOME` still gets
+written on every new component project, either inherited from the parent project's existing
+value or as an empty placeholder ready to be filled in directly in TeamCity.

--- a/openspec/changes/set-env-java-home-default-param/proposal.md
+++ b/openspec/changes/set-env-java-home-default-param/proposal.md
@@ -23,8 +23,8 @@
   hierarchy (typically published by an agent), not a literal path.
 - **Optional** — omitting it entirely is a supported, unremarkable case (see fallback below).
 - If supplied non-blank, it is wrapped as `%<value>%` when written.
-- Rejected at parse time if already `%`-wrapped — the tool does the wrapping; a caller passing an
-  already-wrapped value almost certainly misunderstands the option.
+- Rejected at parse time if it contains `%` anywhere — the tool does the wrapping; a caller
+  passing `%`, wrapped or half-wrapped, almost certainly misunderstands the option.
 
 **Resolution, in order:**
 1. `--default-java-home`, if supplied (non-blank) → `%<value>%`.

--- a/openspec/changes/set-env-java-home-default-param/proposal.md
+++ b/openspec/changes/set-env-java-home-default-param/proposal.md
@@ -41,8 +41,10 @@ not read `component.buildParameters?.javaVersion` at all. Resolution depends onl
 under that project (compile, RC, checklist, release) inherits it through normal TeamCity
 parameter inheritance.
 
-**No change to `JDK_VERSION`:** its existing logic is untouched; this change does not add a
-deprecation note for it (that was specific to the other approach's rationale, not this one's).
+**`JDK_VERSION` is marked deprecated, not removed:** its own logic is untouched — both parameters
+are set side by side during a migration period. The removal condition is tracked as
+`docs/tech-debt/TD-001-jdk-version-param-removal.md` (this repo's first tech-debt record on this
+branch), referenced from a short `TD-001:` comment on the `JDK_VERSION`-setting block.
 
 ## Affected areas
 
@@ -66,7 +68,8 @@ deprecation note for it (that was specific to the other approach's rationale, no
 - Deriving anything from the component registry's `javaVersion` field.
 - Per-major-version overrides or a `{major}`-style template — this option is a single flat value
   per invocation, not a mapping.
-- Any change to `JDK_VERSION`'s own logic, or a deprecation note referencing it.
+- Any change to `JDK_VERSION`'s own logic.
+- Actually removing `JDK_VERSION` — tracked separately in `TD-001`, gated on consumer migration.
 - Validating that the supplied parameter name corresponds to a real agent-side TeamCity
   parameter — this tool has no visibility into agent configuration.
 

--- a/openspec/changes/set-env-java-home-default-param/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-default-param/specs/java-home-resolution/spec.md
@@ -1,0 +1,78 @@
+# Java home resolution
+
+## Purpose
+
+Governs how `create-build-chain` resolves and writes the `env.JAVA_HOME` TeamCity project
+parameter for a newly created component project, from an optional caller-supplied
+`--default-java-home` reference name and, failing that, the parent project's own `env.JAVA_HOME`.
+Does not govern `JDK_VERSION`, which is unchanged. Resolution does not depend on the component
+registry's `javaVersion` field.
+
+## ADDED Requirements
+
+### Requirement: `--default-java-home` accepts a bare TeamCity parameter reference name
+
+`create-build-chain` SHALL accept an optional `--default-java-home` option whose value, when
+supplied non-blank, SHALL be a bare TeamCity parameter name (not `%`-wrapped).
+
+- An already-`%`-wrapped value SHALL be rejected before any TeamCity project is created.
+- A blank or absent value SHALL be treated as "not supplied" (see the fallback requirement below).
+
+#### Scenario: bare reference name is accepted
+
+- **WHEN** `--default-java-home=env.JDK_17_0` is supplied
+- **THEN** the command proceeds, and `env.JAVA_HOME` resolves to `%env.JDK_17_0%`
+
+#### Scenario: already-wrapped value is rejected
+
+- **WHEN** `--default-java-home=%env.JDK_17_0%` is supplied
+- **THEN** the command fails before creating any TeamCity project, with a message naming the
+  invalid value
+
+#### Scenario: blank value is treated as omitted
+
+- **WHEN** `--default-java-home=` (blank) is supplied
+- **THEN** the command proceeds as if the option were absent entirely
+
+### Requirement: `--default-java-home`, when supplied non-blank, resolves `env.JAVA_HOME` directly
+
+When `--default-java-home` is supplied non-blank, the command SHALL resolve `env.JAVA_HOME` to
+that value wrapped as `%<value>%`, regardless of the parent project's own `env.JAVA_HOME` or
+anything in the component registry.
+
+#### Scenario: option takes precedence over the parent project's own value
+
+- **WHEN** `--default-java-home=env.JDK_21_0` is supplied and `parentProjectId` has
+  `env.JAVA_HOME` set to `%env.JDK_1_8%`
+- **THEN** the new component project's `env.JAVA_HOME` is set to `%env.JDK_21_0%`
+
+### Requirement: `--default-java-home` omitted falls back to the parent project's `env.JAVA_HOME`, used as-is
+
+When `--default-java-home` is not supplied (or blank), the command SHALL read the existing
+`env.JAVA_HOME` project parameter from `parentProjectId` and use it **without** re-wrapping.
+
+#### Scenario: no option supplied, parent has a value
+
+- **WHEN** `--default-java-home` is not supplied and `parentProjectId` has `env.JAVA_HOME` set to
+  `%env.JDK_1_8%`
+- **THEN** the new component project's `env.JAVA_HOME` is set to `%env.JDK_1_8%`
+
+### Requirement: `env.JAVA_HOME` is always written at project level, empty if nothing resolves
+
+The command SHALL write `env.JAVA_HOME` as a project-level parameter on the newly created
+component project (not build-type-level) unconditionally. If neither `--default-java-home` nor
+the parent project's `env.JAVA_HOME` yields a value, the command SHALL write `env.JAVA_HOME` with
+an **empty string**, not skip the write.
+
+#### Scenario: no option supplied, parent has no value either
+
+- **WHEN** `--default-java-home` is not supplied and `parentProjectId` has no `env.JAVA_HOME` set
+- **THEN** `env.JAVA_HOME` is still written for the new component project, with an empty value
+
+#### Scenario: value inherited by every build configuration in the chain
+
+- **WHEN** `env.JAVA_HOME` resolves to `%env.JDK_17_0%` for a component whose build chain includes
+  compile, RC, checklist, and release build configurations
+- **THEN** all four build configurations resolve `env.JAVA_HOME` to `%env.JDK_17_0%` through
+  TeamCity's normal project-to-build-type parameter inheritance, with no build-type-level override
+  written explicitly

--- a/openspec/changes/set-env-java-home-default-param/specs/java-home-resolution/spec.md
+++ b/openspec/changes/set-env-java-home-default-param/specs/java-home-resolution/spec.md
@@ -13,9 +13,10 @@ registry's `javaVersion` field.
 ### Requirement: `--default-java-home` accepts a bare TeamCity parameter reference name
 
 `create-build-chain` SHALL accept an optional `--default-java-home` option whose value, when
-supplied non-blank, SHALL be a bare TeamCity parameter name (not `%`-wrapped).
+supplied non-blank, SHALL be a bare TeamCity parameter name containing no `%` character.
 
-- An already-`%`-wrapped value SHALL be rejected before any TeamCity project is created.
+- A non-blank value containing `%` anywhere SHALL be rejected before any TeamCity project is
+  created — the tool does the wrapping, so `%` in the input signals a caller misunderstanding.
 - A blank or absent value SHALL be treated as "not supplied" (see the fallback requirement below).
 
 #### Scenario: bare reference name is accepted
@@ -23,9 +24,10 @@ supplied non-blank, SHALL be a bare TeamCity parameter name (not `%`-wrapped).
 - **WHEN** `--default-java-home=env.JDK_17_0` is supplied
 - **THEN** the command proceeds, and `env.JAVA_HOME` resolves to `%env.JDK_17_0%`
 
-#### Scenario: already-wrapped value is rejected
+#### Scenario: value containing `%` is rejected
 
-- **WHEN** `--default-java-home=%env.JDK_17_0%` is supplied
+- **WHEN** `--default-java-home` is supplied as `%env.JDK_17_0%`, `%env.JDK_17_0`, or
+  `env.JDK_17_0%`
 - **THEN** the command fails before creating any TeamCity project, with a message naming the
   invalid value
 

--- a/openspec/changes/set-env-java-home-default-param/tasks.md
+++ b/openspec/changes/set-env-java-home-default-param/tasks.md
@@ -1,0 +1,54 @@
+# Tasks
+
+## 1. `--default-java-home` option and validation (Decisions 1–3)
+
+- [ ] 1.1 `TeamcityCreateBuildChainCommand.kt` — new nullable `defaultJavaHome: String?` option
+      (`option(DEFAULT_JAVA_HOME, help = ...)`, `.convert { it.trim() }`, no `.required()`/
+      `.default()`), plus the `DEFAULT_JAVA_HOME = "--default-java-home"` companion constant
+      alongside `PARENT`/`COMPONENT`/`VERSION`/`CR`/`CREATE_CHECKLIST`/`CREATE_RC_FORCE`.
+- [ ] 1.2 Reject an already-`%`-wrapped value at parse time (`BadParameterValue`, naming the
+      value) via a `.check` or `.validate` on the option. A blank/whitespace-only value is treated
+      as absent (not an error) — normalize to `null` before use.
+
+## 2. Resolve and always write `env.JAVA_HOME` (Decisions 4–6)
+
+- [ ] 2.1 Private `resolveJavaHome(): String` on `TeamcityCreateBuildChainCommand`:
+      1. `defaultJavaHome?.takeIf { it.isNotBlank() }?.let { return "%$it%" }`
+      2. else `client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")`,
+         catching `FeignException.NotFound` → `null`
+      3. else `""`
+- [ ] 2.2 `createBuildChain` calls `setProjectParameter(project.id, "env.JAVA_HOME",
+      resolveJavaHome())` unconditionally, alongside the existing `COMPONENT_NAME` /
+      `PROJECT_VERSION` project-level writes. No change to the `JDK_VERSION` block.
+
+## 3. Metarunner passthrough
+
+- [ ] 3.1 `metarunners/CreateTeamCityBuildChain.xml` — new `%DEFAULT_JAVA_HOME%` parameter,
+      defaulting to `""`, described as optional, passed as
+      `--default-java-home=%DEFAULT_JAVA_HOME%` so every existing build config using this
+      metarunner keeps working unchanged.
+
+## 4. Tests
+
+- [ ] 4.1 Functional tests in `ApplicationTest.kt` — `executeForCreateBuildChainCommand` gains an
+      optional `defaultJavaHome: String? = null` appended to the arg list only when non-null; new
+      `testTeamCityCreateBuildChainForJavaHome`:
+  - [ ] 4.1.1 option supplied → `env.JAVA_HOME` written as `%<value>%` on the project, inherited by
+        compile/RC/checklist/release build configs
+  - [ ] 4.1.2 option supplied, already `%`-wrapped → command fails before creating any project
+  - [ ] 4.1.3 option omitted, parent has `env.JAVA_HOME` → parent's value used as-is (no
+        re-wrapping)
+  - [ ] 4.1.4 option omitted, parent has no `env.JAVA_HOME` → written with an empty string
+  - [ ] 4.1.5 option supplied and blank (`""`) → treated as omitted, falls back to parent
+        resolution (4.1.3/4.1.4)
+
+## 5. Finalization
+
+- [ ] 5.1 `./gradlew compileKotlin compileTestKotlin` clean.
+- [ ] 5.2 `./gradlew detekt ktlintCheck` clean against every file touched.
+- [ ] 5.3 Full suite (including the new functional tests) green on CI per the
+      `build-verification` skill — this environment has no Docker daemon for the
+      compose-backed `test` task.
+- [ ] 5.4 Confirm every `Out of scope` item in `proposal.md` holds: no read of
+      `component.buildParameters?.javaVersion`, no mapping/template mechanism, `JDK_VERSION`
+      logic byte-for-byte unchanged.

--- a/openspec/changes/set-env-java-home-default-param/tasks.md
+++ b/openspec/changes/set-env-java-home-default-param/tasks.md
@@ -48,14 +48,22 @@
   - [x] 4.1.5 option supplied and blank (`""`) → treated as omitted, falls back to parent
         resolution (4.1.3/4.1.4)
 
-## 5. Finalization
+## 5. `JDK_VERSION` deprecation note (Decision 7)
 
-- [x] 5.1 `./gradlew compileKotlin compileTestKotlin` clean.
-- [x] 5.2 `./gradlew detekt ktlintCheck` clean against every file touched.
-- [ ] 5.3 Full suite (including the new functional tests) green on CI per the
+- [x] 5.1 `docs/tech-debt/TD-001-jdk-version-param-removal.md` records the removal condition
+      (Status / Context / Symptoms / Acceptance criteria / Related), following the
+      one-file-per-item convention from the `env-java-home` branch. A `TD-001:` comment on the
+      `JDK_VERSION`-setting block in `TeamcityCreateBuildChainCommand.kt` points at it.
+- [x] 5.2 No behavior or test change — `JDK_VERSION` continues exactly as today.
+
+## 6. Finalization
+
+- [x] 6.1 `./gradlew compileKotlin compileTestKotlin` clean.
+- [x] 6.2 `./gradlew detekt ktlintCheck` clean against every file touched.
+- [ ] 6.3 Full suite (including the new functional tests) green on CI per the
       `build-verification` skill — this environment has no Docker daemon for the
       compose-backed `test` task, so the new `testTeamCityCreateBuildChainForJavaHome` has not
       actually been run yet; it must run on CI before this change is considered verified.
-- [x] 5.4 Confirm every `Out of scope` item in `proposal.md` holds: no read of
+- [x] 6.4 Confirm every `Out of scope` item in `proposal.md` holds: no read of
       `component.buildParameters?.javaVersion`, no mapping/template mechanism, `JDK_VERSION`
       logic byte-for-byte unchanged.

--- a/openspec/changes/set-env-java-home-default-param/tasks.md
+++ b/openspec/changes/set-env-java-home-default-param/tasks.md
@@ -2,53 +2,60 @@
 
 ## 1. `--default-java-home` option and validation (Decisions 1–3)
 
-- [ ] 1.1 `TeamcityCreateBuildChainCommand.kt` — new nullable `defaultJavaHome: String?` option
+- [x] 1.1 `TeamcityCreateBuildChainCommand.kt` — new nullable `defaultJavaHome: String?` option
       (`option(DEFAULT_JAVA_HOME, help = ...)`, `.convert { it.trim() }`, no `.required()`/
       `.default()`), plus the `DEFAULT_JAVA_HOME = "--default-java-home"` companion constant
       alongside `PARENT`/`COMPONENT`/`VERSION`/`CR`/`CREATE_CHECKLIST`/`CREATE_RC_FORCE`.
-- [ ] 1.2 Reject an already-`%`-wrapped value at parse time (`BadParameterValue`, naming the
+- [x] 1.2 Reject an already-`%`-wrapped value at parse time (`BadParameterValue`, naming the
       value) via a `.check` or `.validate` on the option. A blank/whitespace-only value is treated
       as absent (not an error) — normalize to `null` before use.
+      (added on review) Validation is done via `.check` directly on the option chain (not a lazy
+      property), so clikt enforces it during argument parsing — strictly before `run()` executes,
+      i.e. before any TeamCity project is created.
 
 ## 2. Resolve and always write `env.JAVA_HOME` (Decisions 4–6)
 
-- [ ] 2.1 Private `resolveJavaHome(): String` on `TeamcityCreateBuildChainCommand`:
+- [x] 2.1 Private `resolveJavaHome(): String` on `TeamcityCreateBuildChainCommand`:
       1. `defaultJavaHome?.takeIf { it.isNotBlank() }?.let { return "%$it%" }`
       2. else `client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")`,
          catching `FeignException.NotFound` → `null`
       3. else `""`
-- [ ] 2.2 `createBuildChain` calls `setProjectParameter(project.id, "env.JAVA_HOME",
-      resolveJavaHome())` unconditionally, alongside the existing `COMPONENT_NAME` /
-      `PROJECT_VERSION` project-level writes. No change to the `JDK_VERSION` block.
+- [x] 2.2 `createBuildChain` calls `setParameter(ConfigurationType.PROJECT, project.id,
+      "env.JAVA_HOME", resolveJavaHome())` unconditionally, alongside the existing `COMPONENT_NAME`
+      / `PROJECT_VERSION` project-level writes. No change to the `JDK_VERSION` block.
+      (added on review) `setBuildTypeParameter`/`setProjectParameter` merged into one
+      `setParameter(configurationType, id, name, value)` — the extra member pushed the class past
+      detekt's `TooManyFunctions` threshold; see `design.md` Context.
 
 ## 3. Metarunner passthrough
 
-- [ ] 3.1 `metarunners/CreateTeamCityBuildChain.xml` — new `%DEFAULT_JAVA_HOME%` parameter,
+- [x] 3.1 `metarunners/CreateTeamCityBuildChain.xml` — new `%DEFAULT_JAVA_HOME%` parameter,
       defaulting to `""`, described as optional, passed as
       `--default-java-home=%DEFAULT_JAVA_HOME%` so every existing build config using this
       metarunner keeps working unchanged.
 
 ## 4. Tests
 
-- [ ] 4.1 Functional tests in `ApplicationTest.kt` — `executeForCreateBuildChainCommand` gains an
+- [x] 4.1 Functional tests in `ApplicationTest.kt` — `executeForCreateBuildChainCommand` gains an
       optional `defaultJavaHome: String? = null` appended to the arg list only when non-null; new
       `testTeamCityCreateBuildChainForJavaHome`:
-  - [ ] 4.1.1 option supplied → `env.JAVA_HOME` written as `%<value>%` on the project, inherited by
+  - [x] 4.1.1 option supplied → `env.JAVA_HOME` written as `%<value>%` on the project, inherited by
         compile/RC/checklist/release build configs
-  - [ ] 4.1.2 option supplied, already `%`-wrapped → command fails before creating any project
-  - [ ] 4.1.3 option omitted, parent has `env.JAVA_HOME` → parent's value used as-is (no
+  - [x] 4.1.2 option supplied, already `%`-wrapped → command fails before creating any project
+  - [x] 4.1.3 option omitted, parent has `env.JAVA_HOME` → parent's value used as-is (no
         re-wrapping)
-  - [ ] 4.1.4 option omitted, parent has no `env.JAVA_HOME` → written with an empty string
-  - [ ] 4.1.5 option supplied and blank (`""`) → treated as omitted, falls back to parent
+  - [x] 4.1.4 option omitted, parent has no `env.JAVA_HOME` → written with an empty string
+  - [x] 4.1.5 option supplied and blank (`""`) → treated as omitted, falls back to parent
         resolution (4.1.3/4.1.4)
 
 ## 5. Finalization
 
-- [ ] 5.1 `./gradlew compileKotlin compileTestKotlin` clean.
-- [ ] 5.2 `./gradlew detekt ktlintCheck` clean against every file touched.
+- [x] 5.1 `./gradlew compileKotlin compileTestKotlin` clean.
+- [x] 5.2 `./gradlew detekt ktlintCheck` clean against every file touched.
 - [ ] 5.3 Full suite (including the new functional tests) green on CI per the
       `build-verification` skill — this environment has no Docker daemon for the
-      compose-backed `test` task.
-- [ ] 5.4 Confirm every `Out of scope` item in `proposal.md` holds: no read of
+      compose-backed `test` task, so the new `testTeamCityCreateBuildChainForJavaHome` has not
+      actually been run yet; it must run on CI before this change is considered verified.
+- [x] 5.4 Confirm every `Out of scope` item in `proposal.md` holds: no read of
       `component.buildParameters?.javaVersion`, no mapping/template mechanism, `JDK_VERSION`
       logic byte-for-byte unchanged.

--- a/openspec/changes/set-env-java-home-default-param/tasks.md
+++ b/openspec/changes/set-env-java-home-default-param/tasks.md
@@ -6,12 +6,14 @@
       (`option(DEFAULT_JAVA_HOME, help = ...)`, `.convert { it.trim() }`, no `.required()`/
       `.default()`), plus the `DEFAULT_JAVA_HOME = "--default-java-home"` companion constant
       alongside `PARENT`/`COMPONENT`/`VERSION`/`CR`/`CREATE_CHECKLIST`/`CREATE_RC_FORCE`.
-- [x] 1.2 Reject an already-`%`-wrapped value at parse time (`BadParameterValue`, naming the
+- [x] 1.2 Reject any non-blank value containing `%` at parse time (`BadParameterValue`, naming the
       value) via a `.check` or `.validate` on the option. A blank/whitespace-only value is treated
       as absent (not an error) — normalize to `null` before use.
       (added on review) Validation is done via `.check` directly on the option chain (not a lazy
       property), so clikt enforces it during argument parsing — strictly before `run()` executes,
       i.e. before any TeamCity project is created.
+      (added on review) The check rejects `%` anywhere, not just a fully wrapped value — a
+      half-wrapped `%env.JDK_17_0` is just as broken and used to slip through.
 
 ## 2. Resolve and always write `env.JAVA_HOME` (Decisions 4–6)
 
@@ -23,6 +25,9 @@
 - [x] 2.2 `createBuildChain` calls `setParameter(ConfigurationType.PROJECT, project.id,
       "env.JAVA_HOME", resolveJavaHome())` unconditionally, alongside the existing `COMPONENT_NAME`
       / `PROJECT_VERSION` project-level writes. No change to the `JDK_VERSION` block.
+      (added on review) `resolveJavaHome()` is called at the top of `createBuildChain`, before the
+      project is created, and the result held in a local — a failure reading the parent's
+      parameter must not leave a half-built chain behind.
       (added on review) `setBuildTypeParameter`/`setProjectParameter` merged into one
       `setParameter(configurationType, id, name, value)` — the extra member pushed the class past
       detekt's `TooManyFunctions` threshold; see `design.md` Context.
@@ -41,7 +46,8 @@
       `testTeamCityCreateBuildChainForJavaHome`:
   - [x] 4.1.1 option supplied → `env.JAVA_HOME` written as `%<value>%` on the project, inherited by
         compile/RC/checklist/release build configs
-  - [x] 4.1.2 option supplied, already `%`-wrapped → command fails before creating any project
+  - [x] 4.1.2 option supplied containing `%` (fully wrapped, or only a leading/trailing `%`) →
+        command fails before creating any project
   - [x] 4.1.3 option omitted, parent has `env.JAVA_HOME` → parent's value used as-is (no
         re-wrapping)
   - [x] 4.1.4 option omitted, parent has no `env.JAVA_HOME` → written with an empty string

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -68,6 +68,10 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         .convert { it.trim().toBoolean() }
         .default(false)
 
+    private val defaultJavaHome by option(DEFAULT_JAVA_HOME, help = "Bare parameter reference for env.JAVA_HOME, e.g. env.JDK_17_0")
+        .convert { it.trim() }
+        .check("$DEFAULT_JAVA_HOME must not already be %-wrapped") { !(it.startsWith("%") && it.endsWith("%")) }
+
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
 
@@ -106,7 +110,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         attachVcsRootToBuildType(compileConfig.id, vcsRootId)
         val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
-            setBuildTypeParameter(compileConfig.id, "JDK_VERSION", projectJDKVersion)
+            setParameter(ConfigurationType.BUILD_TYPE, compileConfig.id, "JDK_VERSION", projectJDKVersion)
         }
         val releaseConfig =
             if ((component.distribution?.explicit == true && component.distribution?.external == true) || createRcForce) {
@@ -125,7 +129,8 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                     )
                     attachVcsRootToBuildType(checklistConfig.id, vcsRootId)
                     addSnapshotDependency(checklistConfig, rcConfig, DependencyFailureAction.CANCEL)
-                    setBuildTypeParameter(
+                    setParameter(
+                        ConfigurationType.BUILD_TYPE,
                         checklistConfig.id,
                         "BUILD_VERSION",
                         "%dep.${compileConfig.id}.BUILD_VERSION%",
@@ -142,7 +147,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 addSnapshotDependency(rcConfig, compileConfig, DependencyFailureAction.CANCEL)
                 addSnapshotDependency(releaseConfig, rcConfig, DependencyFailureAction.CANCEL)
 
-                setBuildTypeParameter(rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
+                setParameter(ConfigurationType.BUILD_TYPE, rcConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
                 releaseConfig
             } else {
                 val releaseConfig = createBuildConf(
@@ -155,10 +160,11 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
                 releaseConfig
             }
         disableBuildStep(releaseConfig.id, "IncrementTeamCityBuildConfigurationParameter")
-        setBuildTypeParameter(releaseConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
-        setBuildTypeParameter(releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
-        setProjectParameter(project.id, "COMPONENT_NAME", componentName)
-        setProjectParameter(project.id, "PROJECT_VERSION", minorVersion)
+        setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BUILD_VERSION", "%dep.${compileConfig.id}.BUILD_VERSION%")
+        setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
+        setParameter(ConfigurationType.PROJECT, project.id, "COMPONENT_NAME", componentName)
+        setParameter(ConfigurationType.PROJECT, project.id, "PROJECT_VERSION", minorVersion)
+        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome())
         (
             listOfNotNull(component.componentOwner) +
                 (component.releaseManager?.split(",") ?: emptyList())
@@ -217,21 +223,23 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         )
     }
 
-    private fun setBuildTypeParameter(
-        buildTypeId: String,
+    private fun setParameter(
+        configurationType: ConfigurationType,
+        id: String,
         name: String,
         value: String,
-    ) = client.setParameter(ConfigurationType.BUILD_TYPE, buildTypeId, name, value).also {
-        log.info("Set parameter $name value $value for build configuration with id $buildTypeId")
+    ) = client.setParameter(configurationType, id, name, value).also {
+        val scope = if (configurationType == ConfigurationType.BUILD_TYPE) "build configuration" else "project"
+        log.info("Set parameter $name value $value for $scope with id $id")
     }
 
-    private fun setProjectParameter(
-        projectId: String,
-        name: String,
-        value: String,
-    ) = client.setParameter(ConfigurationType.PROJECT, projectId, name, value).also {
-        log.info("Set parameter $name value $value for project with id $projectId")
-    }
+    private fun resolveJavaHome(): String =
+        defaultJavaHome?.takeIf { it.isNotBlank() }?.let { "%$it%" }
+            ?: try {
+                client.getParameter(ConfigurationType.PROJECT, parentProjectId, "env.JAVA_HOME")
+            } catch (_: FeignException.NotFound) {
+                ""
+            }
 
     private fun assignProjectAdminRoleToUser(
         projectId: String,
@@ -295,6 +303,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         const val CR = "--registry-url"
         const val CREATE_CHECKLIST = "--create-checklist"
         const val CREATE_RC_FORCE = "--create-rc-force"
+        const val DEFAULT_JAVA_HOME = "--default-java-home"
 
         const val TEMPLATE_GRADLE_COMPILE = "CDCompileUTGradle"
         const val TEMPLATE_MAVEN_COMPILE = "CDCompileUTMaven"

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -70,7 +70,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
 
     private val defaultJavaHome by option(DEFAULT_JAVA_HOME, help = "Bare parameter reference for env.JAVA_HOME, e.g. env.JDK_17_0")
         .convert { it.trim() }
-        .check("$DEFAULT_JAVA_HOME must not already be %-wrapped") { !(it.startsWith("%") && it.endsWith("%")) }
+        .check({ "$DEFAULT_JAVA_HOME must be a bare parameter reference without '%', got '$it'" }) { it.isBlank() || !it.contains("%") }
 
     private val client by lazy { context[TeamcityCommand.CLIENT] as TeamcityClient }
     private val log by lazy { context[TeamcityCommand.LOG] as Logger }
@@ -91,6 +91,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         parentProject: TeamcityProject,
         component: DetailedComponent,
     ) {
+        val javaHome = resolveJavaHome()
         val project = client.createProject(
             TeamcityCreateProject(name = componentName, parentProject = TeamcityLinkProject(id = parentProject.id)),
         )
@@ -165,7 +166,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
         setParameter(ConfigurationType.BUILD_TYPE, releaseConfig.id, "BASE_CONFIGURATION_ID", compileConfig.id)
         setParameter(ConfigurationType.PROJECT, project.id, "COMPONENT_NAME", componentName)
         setParameter(ConfigurationType.PROJECT, project.id, "PROJECT_VERSION", minorVersion)
-        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", resolveJavaHome())
+        setParameter(ConfigurationType.PROJECT, project.id, "env.JAVA_HOME", javaHome)
         (
             listOfNotNull(component.componentOwner) +
                 (component.releaseManager?.split(",") ?: emptyList())

--- a/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
+++ b/src/main/kotlin/org/octopusden/octopus/automation/teamcity/TeamcityCreateBuildChainCommand.kt
@@ -108,6 +108,7 @@ class TeamcityCreateBuildChainCommand : CliktCommand(name = COMMAND) {
             project.id,
         )
         attachVcsRootToBuildType(compileConfig.id, vcsRootId)
+        // TD-001: superseded by env.JAVA_HOME below; see docs/tech-debt/TD-001-jdk-version-param-removal.md
         val defaultJDKVersion = client.getParameter(ConfigurationType.PROJECT, parentProjectId, "JDK_VERSION")
         component.buildParameters?.javaVersion?.takeIf { it != defaultJDKVersion }?.let { projectJDKVersion ->
             setParameter(ConfigurationType.BUILD_TYPE, compileConfig.id, "JDK_VERSION", projectJDKVersion)

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -76,6 +76,7 @@ class ApplicationTest {
         minorVersion: String? = "1.0",
         createChecklist: Boolean = true,
         createRcForce: Boolean = false,
+        defaultJavaHome: String? = null,
     ): Int =
         execute(
             testMethodName,
@@ -87,6 +88,7 @@ class ApplicationTest {
             "${TeamcityCreateBuildChainCommand.CR}=http://$hostComponentsRegistry",
             "${TeamcityCreateBuildChainCommand.CREATE_CHECKLIST}=$createChecklist",
             "${TeamcityCreateBuildChainCommand.CREATE_RC_FORCE}=$createRcForce",
+            *listOfNotNull(defaultJavaHome?.let { "${TeamcityCreateBuildChainCommand.DEFAULT_JAVA_HOME}=$it" }).toTypedArray(),
         )
 
     @ParameterizedTest
@@ -601,6 +603,64 @@ class ApplicationTest {
             "11",
             teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, "${customJDKProjectId}_10CompileUtAuto", "JDK_VERSION"),
         )
+    }
+
+    /**
+     * Tests CreateTeamCityBuildChain for resolving and always writing the env.JAVA_HOME project parameter,
+     * from --default-java-home, else the parent project's own env.JAVA_HOME, else an empty value.
+     */
+    @ParameterizedTest
+    @MethodSource("teamcityContexts")
+    fun testTeamCityCreateBuildChainForJavaHome(config: TeamcityTestConfiguration) {
+        val teamcityClient = createClient(config)
+
+        val componentName = "default-jdk-component"
+        val projectId = "TestTeamcityAutomation_DefaultJdkComponent"
+        val nonCompileConfigIds = listOf(
+            "${projectId}_20ReleaseCandidateManual",
+            "${projectId}_30ReleaseChecklistValidationManual",
+            "${projectId}_40ReleaseManual",
+        )
+
+        fun createBuildChainAndGetJavaHome(defaultJavaHome: String? = null): String {
+            Assertions.assertEquals(
+                0,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, defaultJavaHome = defaultJavaHome),
+            )
+            return teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "env.JAVA_HOME")
+        }
+
+        // no option, no env.JAVA_HOME on the parent -> written empty, not omitted; inherited by every build config
+        cleanUpResources(teamcityClient, config)
+        Assertions.assertEquals("", createBuildChainAndGetJavaHome())
+        nonCompileConfigIds.forEach { configId ->
+            Assertions.assertEquals("", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, configId, "env.JAVA_HOME"))
+        }
+
+        // no option, parent has env.JAVA_HOME -> inherited as-is
+        cleanUpResources(teamcityClient, config)
+        teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
+        Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome())
+
+        // option supplied -> resolves directly, wins over the parent's own value
+        cleanUpResources(teamcityClient, config)
+        teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
+        Assertions.assertEquals("%env.JDK_17_0%", createBuildChainAndGetJavaHome("env.JDK_17_0"))
+
+        // option supplied blank -> treated as omitted, falls back to the parent's value
+        cleanUpResources(teamcityClient, config)
+        teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
+        Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(""))
+
+        // option supplied already %-wrapped -> command fails before creating any project
+        cleanUpResources(teamcityClient, config)
+        Assertions.assertEquals(
+            1,
+            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, defaultJavaHome = "%env.JDK_17_0%"),
+        )
+        Assertions.assertThrows(feign.FeignException.NotFound::class.java) {
+            teamcityClient.getProject(projectId)
+        }
     }
 
     /**

--- a/src/test/kotlin/ApplicationTest.kt
+++ b/src/test/kotlin/ApplicationTest.kt
@@ -614,9 +614,10 @@ class ApplicationTest {
     fun testTeamCityCreateBuildChainForJavaHome(config: TeamcityTestConfiguration) {
         val teamcityClient = createClient(config)
 
-        val componentName = "default-jdk-component"
-        val projectId = "TestTeamcityAutomation_DefaultJdkComponent"
-        val nonCompileConfigIds = listOf(
+        val componentName = "ee-component"
+        val projectId = "TestTeamcityAutomation_EeComponent"
+        val chainConfigIds = listOf(
+            "${projectId}_10CompileUtAuto",
             "${projectId}_20ReleaseCandidateManual",
             "${projectId}_30ReleaseChecklistValidationManual",
             "${projectId}_40ReleaseManual",
@@ -630,36 +631,41 @@ class ApplicationTest {
             return teamcityClient.getParameter(ConfigurationType.PROJECT, projectId, "env.JAVA_HOME")
         }
 
-        // no option, no env.JAVA_HOME on the parent -> written empty, not omitted; inherited by every build config
+        // no option, no env.JAVA_HOME on the parent -> written empty, not omitted
         cleanUpResources(teamcityClient, config)
         Assertions.assertEquals("", createBuildChainAndGetJavaHome())
-        nonCompileConfigIds.forEach { configId ->
-            Assertions.assertEquals("", teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, configId, "env.JAVA_HOME"))
-        }
 
         // no option, parent has env.JAVA_HOME -> inherited as-is
         cleanUpResources(teamcityClient, config)
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
         Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome())
 
-        // option supplied -> resolves directly, wins over the parent's own value
+        // option supplied -> resolves directly, wins over the parent's own value, inherited by every build config
         cleanUpResources(teamcityClient, config)
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
         Assertions.assertEquals("%env.JDK_17_0%", createBuildChainAndGetJavaHome("env.JDK_17_0"))
+        chainConfigIds.forEach { configId ->
+            Assertions.assertEquals(
+                "%env.JDK_17_0%",
+                teamcityClient.getParameter(ConfigurationType.BUILD_TYPE, configId, "env.JAVA_HOME"),
+            )
+        }
 
         // option supplied blank -> treated as omitted, falls back to the parent's value
         cleanUpResources(teamcityClient, config)
         teamcityClient.setParameter(ConfigurationType.PROJECT, TEST_PROJECT, "env.JAVA_HOME", "%env.JDK_1_8%")
         Assertions.assertEquals("%env.JDK_1_8%", createBuildChainAndGetJavaHome(""))
 
-        // option supplied already %-wrapped -> command fails before creating any project
-        cleanUpResources(teamcityClient, config)
-        Assertions.assertEquals(
-            1,
-            executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, defaultJavaHome = "%env.JDK_17_0%"),
-        )
-        Assertions.assertThrows(feign.FeignException.NotFound::class.java) {
-            teamcityClient.getProject(projectId)
+        // any value containing '%' -> command fails before creating any project
+        listOf("%env.JDK_17_0%", "%env.JDK_17_0", "env.JDK_17_0%").forEach { invalidValue ->
+            cleanUpResources(teamcityClient, config)
+            Assertions.assertEquals(
+                1,
+                executeForCreateBuildChainCommand(config, testInfo.methodName(), componentName, defaultJavaHome = invalidValue),
+            )
+            Assertions.assertThrows(feign.FeignException.NotFound::class.java) {
+                teamcityClient.getProject(projectId)
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `--default-java-home` option when creating TeamCity build chains.
  - Java home values can be inherited from the parent project or default to an empty value.
  - The resolved Java home is applied across generated build configurations.

- **Bug Fixes**
  - Added validation for invalid or already-wrapped Java home parameter values.

- **Tests**
  - Added coverage for explicit, inherited, blank, and fallback Java home scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Upgrade Notes

- A new optional parameter, `DEFAULT_JAVA_HOME`, has been added.
- This change ensures that every newly created TeamCity project explicitly defines the `env.JAVA_HOME` parameter.
- The value is resolved in the following order:
  1. `DEFAULT_JAVA_HOME`, if set.
  2. The parent project’s `env.JAVA_HOME`, if `DEFAULT_JAVA_HOME` is not set.
  3. An empty string, if neither value is set.